### PR TITLE
Introduce persona-based docs

### DIFF
--- a/.docforge/manifest.yaml
+++ b/.docforge/manifest.yaml
@@ -1,0 +1,12 @@
+structure:
+- name: _index.md
+  source: /README.md
+- name: usage
+  properties:
+    frontmatter:
+      title: Usage
+      weight: 3
+      categories:
+        - Users
+  nodesSelector:
+    path: /docs/usage


### PR DESCRIPTION
**What this PR does / why we need it**:
We would like to introduce persona-based docs focussing on the already known release notes personas and therefore "cleanup" the structure somewhat:
- users (`/docs/usage`)
- operators (`/docs/operations`)
- developers (`/docs/development`)

**Special notes for your reviewer**:
cc @n-boshnakov

**Release note**:
None as ~30 PRs have/will be opened and the message would be the same everywhere (no relevant content changes either) while the only thing that actually changes in the end is the docs page that will have its release note.

/kind/cleanup
