### PR TITLE
Add support for projected volume kubeconfig

### DIFF
--- a/charts/gardener-extension-shoot-rsyslog-relp-admission/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-extension-shoot-rsyslog-relp-admission/charts/runtime/templates/deployment.yaml
@@ -47,6 +47,9 @@ spec:
         {{- if .Values.kubeconfig }}
         - --kubeconfig=/etc/gardener-extension-shoot-rsyslog-relp-admission/kubeconfig/kubeconfig
         {{- end }}
+        {{- if .Values.projectedKubeconfig }}
+        - --kubeconfig={{ required ".Values.projectedKubeconfig.baseMountPath is required" .Values.projectedKubeconfig.baseMountPath }}/kubeconfig
+        {{- end }}
         {{- if .Values.metricsPort }}
         - --metrics-bind-address=:{{ .Values.metricsPort }}
         {{- end }}
@@ -85,6 +88,11 @@ spec:
           mountPath: /var/run/secrets/projected/serviceaccount
           readOnly: true
         {{- end }}
+        {{- if .Values.projectedKubeconfig }}
+        - name: kubeconfig
+          mountPath: {{ required ".Values.projectedKubeconfig.baseMountPath is required" .Values.projectedKubeconfig.baseMountPath }}
+          readOnly: true
+        {{- end }}
       volumes:
       - name: {{ include "name" . }}-tls
         secret:
@@ -106,4 +114,22 @@ spec:
               {{- if .Values.serviceAccountTokenVolumeProjection.audience }}
               audience: {{ .Values.serviceAccountTokenVolumeProjection.audience }}
               {{- end }}
+      {{- end }}
+      {{- if .Values.projectedKubeconfig }}
+      - name: kubeconfig
+        projected:
+          defaultMode: 420
+          sources:
+          - secret:
+              items:
+              - key: kubeconfig
+                path: kubeconfig
+              name: {{ required ".Values.projectedKubeconfig.genericKubeconfigSecretName is required" .Values.projectedKubeconfig.genericKubeconfigSecretName }}
+              optional: false
+          - secret:
+              items:
+              - key: token
+                path: token
+              name: {{ required ".Values.projectedKubeconfig.tokenSecretName is required" .Values.projectedKubeconfig.tokenSecretName }}
+              optional: false
       {{- end }}

--- a/charts/gardener-extension-shoot-rsyslog-relp-admission/charts/runtime/values.yaml
+++ b/charts/gardener-extension-shoot-rsyslog-relp-admission/charts/runtime/values.yaml
@@ -37,6 +37,11 @@ webhookConfig:
 # Kubeconfig to the target cluster. In-cluster configuration will be used if not specified.
 kubeconfig:
 
+# projectedKubeconfig:
+#   baseMountPath: /var/run/secrets/gardener.cloud
+#   genericKubeconfigSecretName: generic-token-kubeconfig
+#   tokenSecretName: access-shoot-rsyslog-relp-admission
+
 serviceAccountTokenVolumeProjection:
   enabled: false
   expirationSeconds: 43200

--- a/charts/gardener-extension-shoot-rsyslog-relp-admission/values.yaml
+++ b/charts/gardener-extension-shoot-rsyslog-relp-admission/values.yaml
@@ -55,6 +55,11 @@ runtime:
   # Kubeconfig to the target cluster. In-cluster configuration will be used if not specified.
   kubeconfig:
 
+# projectedKubeconfig:
+#   baseMountPath: /var/run/secrets/gardener.cloud
+#   genericKubeconfigSecretName: generic-token-kubeconfig
+#   tokenSecretName: access-shoot-rsyslog-relp-admission
+
   serviceAccountTokenVolumeProjection:
     enabled: false
     expirationSeconds: 43200


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR adds the option to configure a projected volume for the validator which can be used as a kubeconfig. It is for example needed, if operators generate their kubeconfigs for the virtual garden cluster via the [TokenRequestor](https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#tokeninvalidator-controller).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `gardener-extension-shoot-rsyslog-relp-admission` chart allows to optionally configure a projected volume based kubeconfig.
```
