### PR TITLE
Fix e2e test flake for shoots created with the `shoot-rsyslog-relp` extension already enabled

### DIFF
--- a/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
+++ b/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 		defer cancel()
 		verifier, err := newVerifier(ctx, f.Logger, f.ShootFramework.SeedClient, f.ShootFramework.ShootSeedNamespace(), "local", f.Shoot.Name, string(f.Shoot.UID))
 		Expect(err).NotTo(HaveOccurred())
-		verifier.verifyThatLogsAreSentToEchoServer(ctx, "test-program", "1", "this should get sent to echo server")
+		verifier.verifyThatLogsAreSentToEchoServer(ctx, "test-program", "1", "this should get sent to echo server", 20*time.Second)
 		verifier.verifyThatLogsAreNotSentToEchoServer(ctx, "other-program", "1", "this should not get sent to echo server")
 		verifier.verifyThatLogsAreNotSentToEchoServer(ctx, "test-program", "3", "this should not get sent to echo server")
 
@@ -64,7 +64,7 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 		By("Verify that shoot-rsyslog-relp works after wake up")
 		ctx, cancel = context.WithTimeout(parentCtx, 5*time.Minute)
 		defer cancel()
-		verifier.verifyThatLogsAreSentToEchoServer(ctx, "test-program", "1", "this should get sent to echo server")
+		verifier.verifyThatLogsAreSentToEchoServer(ctx, "test-program", "1", "this should get sent to echo server", 20*time.Second)
 		verifier.verifyThatLogsAreNotSentToEchoServer(ctx, "other-program", "1", "this should not get sent to echo server")
 		verifier.verifyThatLogsAreNotSentToEchoServer(ctx, "test-program", "3", "this should not get sent to echo server")
 

--- a/test/e2e/test_common.go
+++ b/test/e2e/test_common.go
@@ -80,20 +80,20 @@ func newVerifier(ctx context.Context, log logr.Logger, c kubernetes.Interface, s
 	}, nil
 }
 
-func (v *verifier) verifyThatLogsAreSentToEchoServer(ctx context.Context, programName, severity, logMessage string) {
+func (v *verifier) verifyThatLogsAreSentToEchoServer(ctx context.Context, programName, severity, logMessage string, args ...interface{}) {
 	EventuallyWithOffset(1, func(g Gomega) {
 		logLines, err := v.generateAndGetLogs(ctx, programName, severity, logMessage)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(logLines).To(ContainElement(MatchRegexp(v.constructRegex(programName, logMessage))))
-	}).Should(Succeed())
+	}, args...).Should(Succeed())
 }
 
-func (v *verifier) verifyThatLogsAreNotSentToEchoServer(ctx context.Context, programName, severity, logMessage string) {
+func (v *verifier) verifyThatLogsAreNotSentToEchoServer(ctx context.Context, programName, severity, logMessage string, args ...interface{}) {
 	ConsistentlyWithOffset(1, func(g Gomega) {
 		logLines, err := v.generateAndGetLogs(ctx, programName, severity, logMessage)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(logLines).NotTo(ContainElement(MatchRegexp(v.constructRegex(programName, logMessage))))
-	}).Should(Succeed())
+	}, args...).Should(Succeed())
 }
 
 func (v *verifier) generateAndGetLogs(ctx context.Context, programName, severity, logMessage string) ([]string, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes another issue that could cause flakes when a shoot is created with the `shoot-rsyslog-relp` extension already enabled. After rsyslog-relp is installed on the shoot node, we should wait for at least 15 seconds to make sure that the script which configures rsyslog on the node has a chance to run.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
