### PR TITLE
Adds PriorityClass to daemonsets' pods deployed in the shoot cluster

### DIFF
--- a/charts/internal/rsyslog-relp-configuration-cleaner/templates/daemonset.yaml
+++ b/charts/internal/rsyslog-relp-configuration-cleaner/templates/daemonset.yaml
@@ -19,6 +19,7 @@ spec:
       labels:
 {{ include "labels" . | indent 8 }}
     spec:
+      priorityClassName: gardener-shoot-system-700
       containers:
       - name: pause-container
         image: {{ .Values.images.pause }}

--- a/charts/internal/rsyslog-relp-configurator/templates/daemonset.yaml
+++ b/charts/internal/rsyslog-relp-configurator/templates/daemonset.yaml
@@ -24,6 +24,7 @@ spec:
       labels:
 {{ include "labels" . | indent 8 }}
     spec:
+      priorityClassName: gardener-shoot-system-700
       containers:
       - name: pause
         image: {{ .Values.images.pause }}

--- a/test/integration/controller/lifecycle/lifecycle_test.go
+++ b/test/integration/controller/lifecycle/lifecycle_test.go
@@ -57,6 +57,7 @@ spec:
         app.kubernetes.io/name: rsyslog-relp-configuration-cleaner
         app.kubernetes.io/instance: rsyslog-relp-configuration-cleaner
     spec:
+      priorityClassName: gardener-shoot-system-700
       containers:
       - name: pause-container
         image: registry.k8s.io/pause:3.7
@@ -325,6 +326,7 @@ spec:
         app.kubernetes.io/name: rsyslog-relp-configurator
         app.kubernetes.io/instance: rsyslog-relp-configurator
     spec:
+      priorityClassName: gardener-shoot-system-700
       containers:
       - name: pause
         image: registry.k8s.io/pause:3.7


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a priority class to the `rsyslog-configurator` and `rsyslog-configuration-cleaner` pods so that they can be properly scheduled. This was previously missed to be added.

 I have chosen `gardener-shoot-system-700` so that the rsyslog-relp pods do not preempt the `node-problem-detector` and other critical `daemonsets`. Also it makes sense to have the same priority as other log/metric exporters.

**Which issue(s) this PR fixes**:
Fixes #16 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Added the `gardener-shoot-system-700` priority class to the `rsyslog-relp-configurator` and `rsyslog-relp-configuration-cleaner` pods.
```
