### PR TITLE
skaffold: Rebuild when there are changes to `go:embed` files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,9 +104,10 @@ check-docforge: $(DOCFORGE)
 	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/check-docforge.sh $(REPO_ROOT) $(REPO_ROOT)/.docforge/manifest.yaml ".docforge/;docs/" "gardener-extension-shoot-rsyslog-relp" false
 
 .PHONY: check
-check: $(GOIMPORTS) $(GOLANGCI_LINT) $(HELM)
+check: $(GOIMPORTS) $(GOLANGCI_LINT) $(HELM) $(YQ)
 	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/check.sh --golangci-lint-config=./.golangci.yaml ./cmd/... ./pkg/... ./test/...
 	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/check-charts.sh ./charts
+	@hack/check-skaffold-deps.sh
 
 .PHONY: generate
 generate: $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(HELM) $(YQ)

--- a/hack/check-skaffold-deps.sh
+++ b/hack/check-skaffold-deps.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+echo "> Check Skaffold Dependencies"
+
+check_successful=true
+
+out_dir=$(mktemp -d)
+function cleanup_output {
+  rm -rf "$out_dir"
+}
+trap cleanup_output EXIT
+
+function check() {
+  skaffold_file="$1"
+  binary_name="$2"
+  skaffold_config_name="$3"
+
+  skaffold_yaml="$(cat "$(dirname "$0")/../$skaffold_file")"
+
+  path_current_skaffold_dependencies="${out_dir}/current-$skaffold_file-deps-$binary_name.txt"
+  path_actual_dependencies="${out_dir}/actual-$skaffold_file-deps-$binary_name.txt"
+
+  echo "$skaffold_yaml" |\
+    yq eval "select(.metadata.name == \"$skaffold_config_name\") | .build.artifacts[] | select(.ko.main == \"./cmd/$binary_name\") | .ko.dependencies.paths[]?" - |\
+    sort |\
+    uniq > "$path_current_skaffold_dependencies"
+
+  go list -f '{{ join .Deps "\n" }}' "./cmd/$binary_name" |\
+    grep "github.com/gardener/gardener-extension-shoot-rsyslog-relp/" |\
+    sed 's/github\.com\/gardener\/gardener-extension-shoot-rsyslog-relp\///g' |\
+    sort |\
+    uniq > "$path_actual_dependencies"
+
+  # always add vendor directory and VERSION file
+  echo "vendor" >> "$path_actual_dependencies"
+  echo "VERSION" >> "$path_actual_dependencies"
+
+  # sort dependencies
+  sort -o $path_current_skaffold_dependencies{,}
+  sort -o $path_actual_dependencies{,}
+
+  echo -n ">> Checking defined dependencies in Skaffold config '$skaffold_config_name' for '$binary_name' in '$skaffold_file'..."
+  if ! diff="$(diff "$path_current_skaffold_dependencies" "$path_actual_dependencies")"; then
+    check_successful=false
+
+    echo
+    echo ">>> The following actual dependencies are missing in $skaffold_file (need to be added):"
+    echo "$diff" | grep '>' | awk '{print $2}'
+    echo
+    echo ">>> The following dependencies defined in $skaffold_file are not needed actually (need to be removed):"
+    echo "$diff" | grep '<' | awk '{print $2}'
+    echo
+  else
+    echo " success."
+  fi
+}
+
+check "skaffold.yaml" "gardener-extension-shoot-rsyslog-relp" "extension"
+check "skaffold.yaml" "gardener-extension-shoot-rsyslog-relp-admission" "admission"
+
+if [ "$check_successful" = false ] ; then
+  exit 1
+fi

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -28,6 +28,24 @@ build:
   artifacts:
   - image: eu.gcr.io/gardener-project/gardener/extensions/shoot-rsyslog-relp
     ko:
+      dependencies:
+        paths:
+        - charts
+        - cmd/gardener-extension-shoot-rsyslog-relp/app
+        - pkg/apis/config
+        - pkg/apis/config/v1alpha1
+        - pkg/apis/rsyslog
+        - pkg/apis/rsyslog/install
+        - pkg/apis/rsyslog/v1alpha1
+        - pkg/cmd/rsyslogrelp
+        - pkg/constants
+        - pkg/controller/config
+        - pkg/controller/healthcheck
+        - pkg/controller/lifecycle
+        - pkg/imagevector
+        - pkg/utils
+        - vendor
+        - VERSION
       main: ./cmd/gardener-extension-shoot-rsyslog-relp
 resourceSelector:
   allow:
@@ -48,6 +66,19 @@ build:
   artifacts:
   - image: eu.gcr.io/gardener-project/gardener/extensions/shoot-rsyslog-relp-admission
     ko:
+      dependencies:
+        paths:
+        - cmd/gardener-extension-shoot-rsyslog-relp-admission/app
+        - pkg/admission/cmd
+        - pkg/admission/validator
+        - pkg/apis/rsyslog
+        - pkg/apis/rsyslog/install
+        - pkg/apis/rsyslog/v1alpha1
+        - pkg/apis/rsyslog/validation
+        - pkg/constants
+        - pkg/utils
+        - vendor
+        - VERSION
       main: ./cmd/gardener-extension-shoot-rsyslog-relp-admission
 deploy:
   helm:


### PR DESCRIPTION
**How to categorize this PR?**

/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Currently, the ko builder does not detect changes to go:embed files (see https://github.com/GoogleContainerTools/skaffold/issues/7836). This makes impossible the development of some scripts that are used later by go:embed. This PR inspires from https://github.com/gardener/gardener/pull/6735, https://github.com/gardener/gardener/pull/6781 and https://github.com/gardener/gardener-extension-registry-cache/pull/57 and does the same for the `shoot-rsyslog-relp` extension. 

After https://github.com/gardener/gardener/pull/8630 is merged and g/g released with it we can revendor gardener and make use of the exported functionality. 

**Which issue(s) this PR fixes**:
Part of #2

**Special notes for your reviewer**:
/cc @ialidzhikov 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
