### PR TITLE
Do not deploy the rsyslog-relp-configuration-cleaner on Shoot deletion

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -200,6 +200,13 @@ func (a *actuator) Delete(ctx context.Context, _ logr.Logger, ex *extensionsv1al
 		return err
 	}
 
+	// If the Shoot is in deletion, then there is no need to clean up the rsyslog configuration from Nodes.
+	// The Shoot deletion flows ensures that the Worker is deleted before the Extension deletion.
+	// Hence, there are no Nodes, no need to clean up rsyslog configuration.
+	if cluster.Shoot.DeletionTimestamp != nil {
+		return nil
+	}
+
 	chartRenderer, err := a.chartRendererFactory.NewChartRendererForShoot(cluster.Shoot.Spec.Kubernetes.Version)
 	if err != nil {
 		return fmt.Errorf("could not create chart renderer for shoot '%s', %w", namespace, err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind enhancement

**What this PR does / why we need it**:
Similrly to https://github.com/gardener/gardener-extension-registry-cache/pull/83, if the Shoot is in deletion, then there is no need to clean up the rsyslog configuration from Nodes. The Shoot deletion flow ensures that the Worker is deleted before the Extension deletion.
https://github.com/gardener/gardener/blob/6f8ce7692f793e583734f533cfdee7b9d93fb815/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go#L436-L440

The `deleteExtensionResourcesBeforeKubeAPIServer` step depends on `waitUntilManagedResourcesDeleted` which depends on `deleteManagedResources` which depends on `waitUntilWorkerDeleted`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `rsyslog-relp-configuration-cleaner` is no longer deployed on Shoot deletion with `shoot-rsyslog-relp` extension enabled. The Extension deletion occurs after the Worker deletion. There are no Nodes, hence there is no need to clean up registry configuration.
```
