### PR TITLE
Fix name of `Shoot` used for the tls `E2E` test

### DIFF
--- a/test/e2e/create_enable_disable_delete.go
+++ b/test/e2e/create_enable_disable_delete.go
@@ -93,7 +93,7 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 	Context("shoot-rsyslog-relp extension with tls enabled", Label("tls-enabled"), func() {
 		var createdResources []client.Object
 		f := defaultShootCreationFramework()
-		f.Shoot = e2e.DefaultShoot("e2e-rslog-relp")
+		f.Shoot = e2e.DefaultShoot("e2e-rslog-tls")
 
 		enableExtensionFunc := func(shoot *gardencorev1beta1.Shoot) error {
 			shoot.Spec.Extensions = append(shoot.Spec.Extensions, shootRsyslogRelpExtension(withPort(443), withTLSWithSecretRefName("rsyslog-relp-tls")))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/pull/27 introduced a new `E2E` which verifies that logs are sent to the `rsyslog-relp-echo-server` when the communication is secured with tls. However, the test incorrectly reused the name of the shoot from the already existing `E2E` test: https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/blob/181c9f02573eba42a828550232c3f8cad533d9ae/test/e2e/create_enable_disable_delete.go#L83 and https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/blob/181c9f02573eba42a828550232c3f8cad533d9ae/test/e2e/create_enable_disable_delete.go#L96

This PR fixes the issue by specifying a different name for the new test.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
