### PR TITLE
Update `pause` and `alpine` images and skip scans for the `alpine` image

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -6,16 +6,23 @@
 images:
 - name: alpine
   repository: eu.gcr.io/gardener-project/3rd/alpine
-  tag: "3.15.8"
-
-- name: pause-container
-  sourceRepository: github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile
-  repository: registry.k8s.io/pause
-  tag: "3.7"
+  tag: "3.18.4"
   labels:
   - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
     value:
       policy: skip
       comment: >
-        pause-container is not accessible from outside k8s clusters and not
-        interacted with from other containers or other systems
+        The alpine container is not accessible from outside k8s clusters and not
+        interacted with from other containers or other systems.
+
+- name: pause-container
+  sourceRepository: github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile
+  repository: registry.k8s.io/pause
+  tag: "3.9"
+  labels:
+  - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
+    value:
+      policy: skip
+      comment: >
+        The pause container is not accessible from outside k8s clusters and not
+        interacted with from other containers or other systems.

--- a/test/integration/controller/lifecycle/lifecycle_test.go
+++ b/test/integration/controller/lifecycle/lifecycle_test.go
@@ -67,11 +67,11 @@ spec:
       priorityClassName: gardener-shoot-system-700
       containers:
       - name: pause-container
-        image: registry.k8s.io/pause:3.7
+        image: registry.k8s.io/pause:3.9
         imagePullPolicy: IfNotPresent
       initContainers:
       - name: rsyslog-configuration-cleaner
-        image: eu.gcr.io/gardener-project/3rd/alpine:3.15.8
+        image: eu.gcr.io/gardener-project/3rd/alpine:3.18.4
         imagePullPolicy: IfNotPresent
         command:
         - "sh"
@@ -348,11 +348,11 @@ spec:
       priorityClassName: gardener-shoot-system-700
       containers:
       - name: pause
-        image: registry.k8s.io/pause:3.7
+        image: registry.k8s.io/pause:3.9
         imagePullPolicy: IfNotPresent
       initContainers:
       - name: rsyslog-relp-configurator
-        image: eu.gcr.io/gardener-project/3rd/alpine:3.15.8
+        image: eu.gcr.io/gardener-project/3rd/alpine:3.18.4
         imagePullPolicy: IfNotPresent
         command:
         - "sh"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind enhancement

**What this PR does / why we need it**:
This PR updates the  `pause` and `alpine`  container images to `3.9` and `3.18.4`,  respectively.
It also labels the `alpine` image to be skipped from security scans as it is not accessible from outside k8s clusters and not interacted with from other containers or other systems. This is the same as the reason to skip the scans of the `pause` container.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Vulnerability scans are disabled for the alpine image as the corresponding container is not accessible from outside of the k8s clusters and not interacted with from other containers or other systems.
```
```other operator
The following images are updated:
- `eu.gcr.io/gardener-project/3rd/alpine`: 3.15.8 -> 3.18.4
- `registry.k8s.io/pause`: 3.7 -> 3.9
```