### PR TITLE
Check if `syslog.service` symlink exists before configuring and restarting `rsyslog.service`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ verify-extended: check-generate check format test test-cov test-clean
 test-e2e-local: $(GINKGO)
 	./hack/test-e2e-local.sh --procs=$(PARALLEL_E2E_TESTS) ./test/e2e/...
 
-ci-e2e-kind: $(KIND)
+ci-e2e-kind: $(KIND) $(YQ)
 	./hack/ci-e2e-kind.sh
 
 # use static label for skaffold to prevent rolling all gardener components on every `skaffold` invocation

--- a/charts/internal/rsyslog-relp-configurator/templates/configmap.yaml
+++ b/charts/internal/rsyslog-relp-configurator/templates/configmap.yaml
@@ -43,9 +43,12 @@ data:
     }
 
     function configure_rsyslog() {
-      if [[ ! -f etc/rsyslog.d/60-audit.conf ]] || ! diff -rq /var/lib/rsyslog-relp-configurator/rsyslog.d/60-audit.conf /etc/rsyslog.d/60-audit.conf ; then
+      if [[ ! -f /etc/rsyslog.d/60-audit.conf ]] || ! diff -rq /var/lib/rsyslog-relp-configurator/rsyslog.d/60-audit.conf /etc/rsyslog.d/60-audit.conf ; then
         cp -fL /var/lib/rsyslog-relp-configurator/rsyslog.d/60-audit.conf /etc/rsyslog.d/60-audit.conf
         systemctl restart rsyslog
+      elif ! systemctl is-active --quiet rsyslog.service ; then
+        # Ensure that the rsyslog service is running.
+        systemctl start rsyslog.service
       fi
     }
 
@@ -56,11 +59,14 @@ data:
       echo "auditd.service is not installed, skipping configuration"
     fi
 
-    if systemctl list-unit-files rsyslog.service > /dev/null; then
+    # Make sure that the syslog.service symlink which points to the rsyslog.service unit is created before attempting
+    # to configure rsyslog to ensure proper startup of the rsyslog.service.
+    if systemctl list-unit-files syslog.service > /dev/null && \
+      systemctl list-unit-files rsyslog.service > /dev/null; then
       echo "Configuring rsyslog.service ..."
       configure_rsyslog
     else
-      echo "rsyslog.service is not installed, skipping configuration"
+      echo "rsyslog.service and syslog.service are not installed, skipping configuration"
     fi
 
   60-audit.conf: |


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind bug

**What this PR does / why we need it**:
This PR fixes the configuration and startup of the `rsyslog.service` unit in cases where the `shoot-rsyslog-relp` extension was enabled, but the `rsyslog-relp` package is not present on the nodes and is installed at some later date (this is partially what the https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/blob/main/test/e2e/create_enabled_hibernate_reconcile_delete_test.go `e2e` test does)

More concretely the `configure-rsyslog.sh` script will now wait for the `syslog.service` symlink which points to the `rsyslog.service` unit to be created before attempting to configure and restart the `rsyslog.service`. More information on why this is required is provided in https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/issues/26#issuecomment-1801968833

Additionally, the `configure-rsyslog.sh` script will now check if the `rsysolg.service` is active on each invocation and start it if it is not.

The PR also adds `yq` as a dependency  to the `make ci-e2e-kind` target because it is needed when gathering logs after test failures.

**Which issue(s) this PR fixes**:
Fixes #26 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixed an issue where the rsyslog systemd unit could become stuck in a failed state immediately after it is installed on the shoot's nodes, if the `shoot-rsyslog-relp` extension was enabled on the shoot before that. The `configure-rsyslog.sh` script which is responsible for configuring and restarting the rsyslog systemd unit will now wait for the `syslog.service` symlink to be created before attempting to configure and restart the rsyslog systemd unit.
```
