### PR TITLE
Do not build images from head updates with concourse

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -9,22 +9,6 @@ gardener-extension-shoot-rsyslog-relp:
     traits:
       version:
         preprocess: 'inject-commit-hash'
-      publish:
-        oci-builder: docker-buildx
-        platforms:
-        - linux/amd64
-        - linux/arm64
-        dockerimages:
-          gardener-extension-shoot-rsyslog-relp:
-            registry: 'gcr-readwrite'
-            image: 'eu.gcr.io/gardener-project/gardener/extensions/shoot-rsyslog-relp'
-            dockerfile: 'Dockerfile'
-            target: gardener-extension-shoot-rsyslog-relp
-          gardener-extension-shoot-rsyslog-relp-admission:
-            registry: 'gcr-readwrite'
-            image: 'eu.gcr.io/gardener-project/gardener/extensions/shoot-rsyslog-relp-admission'
-            dockerfile: 'Dockerfile'
-            target: gardener-extension-shoot-rsyslog-relp-admission
   jobs:
     head-update:
       traits:
@@ -57,8 +41,17 @@ gardener-extension-shoot-rsyslog-relp:
               slack_cfg_name: 'scp_workspace'
         component_descriptor: ~
         publish:
+          oci-builder: docker-buildx
           dockerimages:
             gardener-extension-shoot-rsyslog-relp:
+              registry: 'gcr-readwrite'
+              image: 'eu.gcr.io/gardener-project/gardener/extensions/shoot-rsyslog-relp'
+              dockerfile: 'Dockerfile'
+              target: gardener-extension-shoot-rsyslog-relp
               tag_as_latest: true
             gardener-extension-shoot-rsyslog-relp-admission:
+              registry: 'gcr-readwrite'
+              image: 'eu.gcr.io/gardener-project/gardener/extensions/shoot-rsyslog-relp-admission'
+              dockerfile: 'Dockerfile'
+              target: gardener-extension-shoot-rsyslog-relp-admission
               tag_as_latest: true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind enhancement

**What this PR does / why we need it**:
* With this PR images will not be built by concourse on head updates. Concourse will still be used for images for release builds. Builds on head updates will instead be done in prow with https://github.com/gardener/ci-infra/pull/1037
* This PR drops the build for arm64
 
**Which issue(s) this PR fixes**:
Part of #2 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
