### PR TITLE
Fixes a flake in the force delete E2E test

### DIFF
--- a/test/e2e/create_enable_force_delete.go
+++ b/test/e2e/create_enable_force_delete.go
@@ -43,7 +43,9 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 		verifier, err := newVerifier(ctx, f.Logger, f.ShootFramework.SeedClient, f.ShootFramework.ShootSeedNamespace(), "local", f.Shoot.Name, string(f.Shoot.UID))
 		Expect(err).NotTo(HaveOccurred())
 
-		verifier.verifyThatLogsAreSentToEchoServer(ctx, "test-program", "1", "this should get sent to echo server")
+		// Use a timeout of 20 seconds to ensure that the rsyslog-configurator service which configures
+		// rsyslog has a chance to run after rsyslog-relp is installed. It runs once every 15 seconds.
+		verifier.verifyThatLogsAreSentToEchoServer(ctx, "test-program", "1", "this should get sent to echo server", 20*time.Second)
 		verifier.verifyThatLogsAreNotSentToEchoServer(ctx, "other-program", "1", "this should not get sent to echo server")
 		verifier.verifyThatLogsAreNotSentToEchoServer(ctx, "test-program", "3", "this should not get sent to echo server")
 

--- a/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
+++ b/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
@@ -40,6 +40,9 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 		DeferCleanup(cancel)
 		verifier, err := newVerifier(ctx, f.Logger, f.ShootFramework.SeedClient, f.ShootFramework.ShootSeedNamespace(), "local", f.Shoot.Name, string(f.Shoot.UID))
 		Expect(err).NotTo(HaveOccurred())
+
+		// Use a timeout of 20 seconds to ensure that the rsyslog-configurator service which configures
+		// rsyslog has a chance to run after rsyslog-relp is installed. It runs once every 15 seconds
 		verifier.verifyThatLogsAreSentToEchoServer(ctx, "test-program", "1", "this should get sent to echo server", 20*time.Second)
 		verifier.verifyThatLogsAreNotSentToEchoServer(ctx, "other-program", "1", "this should not get sent to echo server")
 		verifier.verifyThatLogsAreNotSentToEchoServer(ctx, "test-program", "3", "this should not get sent to echo server")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind flake

**What this PR does / why we need it**:
This PR fixes a flake in the force delete e2e test which was caused because it starts to generate and check if logs are properly sent to the `rsyslog-relp-echo-server` without waiting long enough so that rsyslog gets configured by the `rsyslog-configurator` service. This behaviour can be observed in the following logs:

```
Dec 05 07:40:09 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz systemd[1]: Started rsyslog configurator daemon.
Dec 05 07:40:09 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz configure-rsyslog.sh[11815]: auditd.service is not installed, skipping configuration
Dec 05 07:40:09 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz configure-rsyslog.sh[11815]: rsyslog.service and syslog.service are not installed, skipping configuration
Dec 05 07:40:09 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz systemd[1]: rsyslog-configurator.service: Succeeded.
Dec 05 07:40:19 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz test-program[13201]: this should get sent to echo server
Dec 05 07:40:19 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz test-program[13209]: this should get sent to echo server
Dec 05 07:40:20 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz test-program[13217]: this should get sent to echo server
Dec 05 07:40:20 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz test-program[13258]: this should get sent to echo server
Dec 05 07:40:20 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz test-program[13266]: this should get sent to echo server
Dec 05 07:40:21 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz test-program[13274]: this should get sent to echo server
Dec 05 07:40:21 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz test-program[13282]: this should get sent to echo server
Dec 05 07:40:21 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz test-program[13290]: this should get sent to echo server
Dec 05 07:40:21 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz test-program[13302]: this should get sent to echo server
Dec 05 07:40:22 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz test-program[13339]: this should get sent to echo server
Dec 05 07:40:22 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz test-program[13352]: this should get sent to echo server
Dec 05 07:40:22 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz test-program[13429]: this should get sent to echo server
Dec 05 07:40:23 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz test-program[13455]: this should get sent to echo server
Dec 05 07:40:23 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz test-program[13486]: this should get sent to echo server
Dec 05 07:40:23 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz test-program[13494]: this should get sent to echo server
Dec 05 07:40:23 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz test-program[13502]: this should get sent to echo server
Dec 05 07:40:24 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz test-program[13510]: this should get sent to echo server
Dec 05 07:40:24 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz test-program[13518]: this should get sent to echo server
Dec 05 07:40:25 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz systemd[1]: rsyslog-configurator.service: Scheduled restart job, restart counter is at 15.
Dec 05 07:40:25 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz systemd[1]: Stopped rsyslog configurator daemon.
Dec 05 07:40:25 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz systemd[1]: Started rsyslog configurator daemon.
Dec 05 07:40:25 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz configure-rsyslog.sh[13559]: auditd.service is not installed, skipping configuration
Dec 05 07:40:25 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz configure-rsyslog.sh[13559]: Configuring rsyslog.service ...
Dec 05 07:40:25 machine-shoot--local--e2e-rslog-fd-local-75775-nm4cz systemd[1]: Listening on Syslog Socket.
```

Here you can see that logs are generated between `Dec 05 07:40:19` and `Dec 05 07:40:24` (so only within 5 seconds). However, rsyslog is successfully configured at `Dec 05 07:40:25`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
