### PR TITLE
Aligns image target names with image registry name

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -47,11 +47,11 @@ gardener-extension-shoot-rsyslog-relp:
               registry: 'gcr-readwrite'
               image: 'eu.gcr.io/gardener-project/gardener/extensions/shoot-rsyslog-relp'
               dockerfile: 'Dockerfile'
-              target: gardener-extension-shoot-rsyslog-relp
+              target: shoot-rsyslog-relp
               tag_as_latest: true
             gardener-extension-shoot-rsyslog-relp-admission:
               registry: 'gcr-readwrite'
               image: 'eu.gcr.io/gardener-project/gardener/extensions/shoot-rsyslog-relp-admission'
               dockerfile: 'Dockerfile'
-              target: gardener-extension-shoot-rsyslog-relp-admission
+              target: shoot-rsyslog-relp-admission
               tag_as_latest: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,14 @@ RUN make install EFFECTIVE_VERSION=$EFFECTIVE_VERSION GOARCH=$TARGETARCH
 FROM gcr.io/distroless/static-debian11:nonroot AS base
 
 ############# gardener-extension-shoot-rsyslog-relp
-FROM base AS gardener-extension-shoot-rsyslog-relp
+FROM base AS shoot-rsyslog-relp
 WORKDIR /
 
 COPY --from=builder /go/bin/gardener-extension-shoot-rsyslog-relp /gardener-extension-shoot-rsyslog-relp
 ENTRYPOINT ["/gardener-extension-shoot-rsyslog-relp"]
 
 ############# gardener-extension-shoot-rsyslog-relp-admission
-FROM base AS gardener-extension-shoot-rsyslog-relp-admission
+FROM base AS shoot-rsyslog-relp-admission
 WORKDIR /
 
 COPY --from=builder /go/bin/gardener-extension-shoot-rsyslog-relp-admission /gardener-extension-shoot-rsyslog-relp-admission


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind bug

**What this PR does / why we need it**:
This PR aligns the target names in the repository's `Dockerfile` with the names of the images' registry. 
This is now necessary because there is no option to explicitly specify the image repository in prow (unlike what was configured in concourse [here](https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/blob/2f627b997dfe73aec65903ad0d0415dd904c1b16/.ci/pipeline_definitions#L48)) and therefore [this configuration](https://github.com/gardener/ci-infra/blob/master/config/jobs/gardener-extension-shoot-rsyslog-relp/gardener-extension-shoot-rsyslog-relp-build-images.yaml) will cause the images built from head updates to be available at `eu.gcr.io/gardener-project/gardener/extensions/gardener-extension-{shoot-rsyslog-relp,shoot-rsyslog-relp-admission}` instead of `eu.gcr.io/gardener-project/gardener/extensions/{shoot-rsyslog-relp,shoot-rsyslog-relp-admission}` where they were created by concourse.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
