### PR TITLE
Increse memory limits for `rsyslog-relp-configurator` and `rsyslog-relp-configuration-cleaner` daemonsets

### DIFF
--- a/charts/internal/rsyslog-relp-configuration-cleaner/templates/daemonset.yaml
+++ b/charts/internal/rsyslog-relp-configuration-cleaner/templates/daemonset.yaml
@@ -64,7 +64,7 @@ spec:
             memory: 8Mi
             cpu: 2m
           limits:
-            memory: 16Mi
+            memory: 32Mi
         volumeMounts:
         - name: host-root-volume
           mountPath: /host

--- a/charts/internal/rsyslog-relp-configurator/templates/daemonset.yaml
+++ b/charts/internal/rsyslog-relp-configurator/templates/daemonset.yaml
@@ -59,7 +59,7 @@ spec:
             memory: 8Mi
             cpu: 2m
           limits:
-            memory: 16Mi
+            memory: 32Mi
         volumeMounts:
         {{- if .Values.rsyslogConfig.tls.enabled }}
         - name: rsyslog-relp-configurator-tls-volume

--- a/test/integration/controller/lifecycle/lifecycle_test.go
+++ b/test/integration/controller/lifecycle/lifecycle_test.go
@@ -106,7 +106,7 @@ spec:
             memory: 8Mi
             cpu: 2m
           limits:
-            memory: 16Mi
+            memory: 32Mi
         volumeMounts:
         - name: host-root-volume
           mountPath: /host
@@ -558,7 +558,7 @@ spec:
             memory: 8Mi
             cpu: 2m
           limits:
-            memory: 16Mi
+            memory: 32Mi
         volumeMounts:` + stringBasedOnCondition(tlsEnabled, `
         - name: rsyslog-relp-configurator-tls-volume
           mountPath: /var/lib/rsyslog-relp-configurator/tls`,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
The `16Mi` memory limit on the init containers of `rsyslog-relp-configurator` and `rsyslog-relp-configuration-cleaner` daemonsets introduced with #44 was still not enough in some deployment scenarios. This PR increases it to `32Mi` 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Incresed memory limits for the init containers of the `rsyslog-relp-configurator` and `rsyslog-relp-configuration-cleaner` daemonsets from `16Mi` to `32Mi`
```
