### PR TITLE
Ensure that `rsyslog.service` is enabled before configuring it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,10 +122,10 @@ ci-e2e-kind: $(KIND) $(YQ)
 # use static label for skaffold to prevent rolling all gardener components on every `skaffold` invocation
 extension-up extension-down: export SKAFFOLD_LABEL = skaffold.dev/run-id=extension-local
 
-extension-up: $(SKAFFOLD) $(HELM) $(KUBECTL)
+extension-up: $(SKAFFOLD) $(HELM) $(KUBECTL) $(KIND)
 	@LD_FLAGS=$(LD_FLAGS) $(SKAFFOLD) run
 
-extension-dev: $(SKAFFOLD) $(HELM) $(KUBECTL)
+extension-dev: $(SKAFFOLD) $(HELM) $(KUBECTL) $(KIND)
 	$(SKAFFOLD) dev --cleanup=false --trigger=manual
 
 extension-down: $(SKAFFOLD) $(HELM) $(KUBECTL)

--- a/pkg/webhook/operatingsystemconfig/testdata/configure-rsyslog.sh
+++ b/pkg/webhook/operatingsystemconfig/testdata/configure-rsyslog.sh
@@ -24,6 +24,11 @@ function configure_auditd() {
 }
 
 function configure_rsyslog() {
+  # Enable the rsyslog service so that necessary symlinks can be created under /etc/systemd/system (e.g. /etc/systemd/system/syslog.service)
+  if ! systemctl is-enabled --quiet rsyslog.service ; then
+    systemctl enable rsyslog.service
+  fi
+
   if [[ ! -f /etc/rsyslog.d/60-audit.conf ]] || ! diff -rq /var/lib/rsyslog-relp-configurator/rsyslog.d/60-audit.conf /etc/rsyslog.d/60-audit.conf ; then
     cp -fL /var/lib/rsyslog-relp-configurator/rsyslog.d/60-audit.conf /etc/rsyslog.d/60-audit.conf
     systemctl restart rsyslog
@@ -40,12 +45,7 @@ else
   echo "auditd.service is not installed, skipping configuration"
 fi
 
-# TODO(plkokanov): due to an issue on gardenlinux, syslog.service is missing: https://github.com/gardenlinux/gardenlinux/issues/1864.
-# This means that for gardenlinux we have to skip the check if syslog.service exists for now.
-# As rsyslog.service comes preinstalled on gardenlinux, this should not lead to configuration problems.
-if grep -q gardenlinux /etc/os-release || \
-  systemctl list-unit-files syslog.service > /dev/null && \
-  systemctl list-unit-files rsyslog.service > /dev/null; then
+if systemctl list-unit-files rsyslog.service > /dev/null; then
   echo "Configuring rsyslog.service ..."
   configure_rsyslog
 else


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind bug

**What this PR does / why we need it**:
This PR fixes a bug where `rsyslog.service` might not run properly if it was not enabled before. When `rsyslog.service` is not enabled, the `/etc/systemd/system/syslog.service` symlink is not created which creates an invalid system logging setup.
This issue was affecting operating systems on which `rsyslog.service` was not enabled by default, e.g. `gardenlinux`.

With this change, it should not be necessary to check if `/etc/systemd/system/syslog.service` exists before configuring `rsyslog.service`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixed an issue where `rsyslog.service` would never get enabled if it was not already enabled by default.
```
