### PR TITLE
Update plutono dashboard tags

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -11,7 +11,7 @@ const (
 	ServiceName = "shoot-rsyslog-relp"
 
 	// Origin is the origin used for the shoot-rsyslog-relp ManagedResources.
-	Origin = "shoot-rsyslog-cache"
+	Origin = "shoot-rsyslog-relp"
 	// ManagedResourceName is the name used to describe the managed shoot resources.
 	ManagedResourceName = "extension-" + ServiceName + "-shoot"
 

--- a/pkg/controller/lifecycle/dashboard_config.go
+++ b/pkg/controller/lifecycle/dashboard_config.go
@@ -2440,8 +2440,9 @@ const dashboardConfig = `{
   "schemaVersion": 27,
   "style": "dark",
   "tags": [
-    "image",
-    "cache"
+    "rsyslog",
+    "audit",
+    "shoot"
   ],
   "templating": {
     "list": [


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
The rsyslog dashboard tags were most likely copied from the registry-cache dashboard and we missed to update them:
![Screenshot 2024-02-22 at 10 48 30](https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/assets/9372594/242a521e-2718-4ee0-8b59-e5f7635dc24f)

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
