### PR TITLE
Use `controller-gen` to generate CRDs used in integration tests

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -24,7 +24,6 @@ Files:
   example/controller-registration.yaml
   hack/api-reference/*.json
   hack/cherry-pick-pull.sh
-  imagevector/images.go
   test/integration/controller/lifecycle/resources/*.yaml
   go.mod
   go.sum

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -25,6 +25,7 @@ Files:
   hack/api-reference/*.json
   hack/cherry-pick-pull.sh
   imagevector/images.go
+  test/integration/controller/lifecycle/resources/*.yaml
   go.mod
   go.sum
   skaffold.yaml

--- a/test/integration/controller/lifecycle/resources/crd-extensions.gardener.cloud_clusters.yaml
+++ b/test/integration/controller/lifecycle/resources/crd-extensions.gardener.cloud_clusters.yaml
@@ -1,14 +1,9 @@
-# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
-#
-# SPDX-License-Identifier: Apache-2.0
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: clusters.extensions.gardener.cloud
 spec:
   group: extensions.gardener.cloud

--- a/test/integration/controller/lifecycle/resources/crd-extensions.gardener.cloud_extensions.yaml
+++ b/test/integration/controller/lifecycle/resources/crd-extensions.gardener.cloud_extensions.yaml
@@ -1,14 +1,9 @@
-# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
-#
-# SPDX-License-Identifier: Apache-2.0
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: extensions.extensions.gardener.cloud
 spec:
   group: extensions.gardener.cloud
@@ -191,13 +186,15 @@ spec:
                       description: ResourceRef is a reference to a resource.
                       properties:
                         apiVersion:
-                          description: API version of the referent
+                          description: apiVersion is the API version of the referent
                           type: string
                         kind:
-                          description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          description: 'kind is the kind of the referent; More info:
+                            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                           type: string
                         name:
-                          description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                          description: 'name is the name of the referent; More info:
+                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
                       required:
                       - kind

--- a/test/integration/controller/lifecycle/resources/crd-resources.gardener.cloud_managedresources.yaml
+++ b/test/integration/controller/lifecycle/resources/crd-resources.gardener.cloud_managedresources.yaml
@@ -1,14 +1,9 @@
-# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
-#
-# SPDX-License-Identifier: Apache-2.0
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: managedresources.resources.gardener.cloud
 spec:
   group: resources.gardener.cloud

--- a/test/integration/controller/lifecycle/resources/doc.go
+++ b/test/integration/controller/lifecycle/resources/doc.go
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:generate sh -c "bash $GARDENER_HACK_DIR/generate-crds.sh -p crd- extensions.gardener.cloud resources.gardener.cloud"
+// Only leave resource kinds which are relevant for the tests: managedresources, clusters, extensions
+// and the doc.go file used for generation
+//go:generate find . -not ( -name *managedresources.yaml -or -name *clusters.yaml -or -name *extensions.yaml -or -name doc.go ) -delete
+
+// Package resources contains generated manifests for CRDs used by the
+// lifecycle controller integration tests.
+package resources


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind enhancement

**What this PR does / why we need it**:
Now that we have bumped `gardener/gardener` to `v1.86.0` and removed the `vendor` folder, we can use `controller-gen` to generate the `managedresources`, `extensions`, and `clusters` CRDs used in the integration tests for this extension.

This fixes the following leftover: https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/pull/39/files#r1420082224

**Which issue(s) this PR fixes**:
Part of #2

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
