### PR TITLE
Only use immutable tls secret

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -123,9 +123,11 @@ loggingRules:
 
 ### Securing the Communication to the Target Server with TLS
 
-The communication to the target server is not encrypted by default. To enable encryption, set the `.tls.enabled` field in the `shoot-rsyslog-relp` extension configuration to `true`. In this case, a secret which contains the TLS certificates used to establish the TLS connection to the server must be created in the same project namespace as your Shoot.
+The communication to the target server is not encrypted by default. To enable encryption, set the `.tls.enabled` field in the `shoot-rsyslog-relp` extension configuration to `true`. In this case, a immutable secret which contains the TLS certificates used to establish the TLS connection to the server must be created in the same project namespace as your Shoot.
 
 An example Secret is given below:
+
+> **Note:**  The secret should be immutable
 
 ```yaml
 kind: Secret
@@ -133,6 +135,7 @@ apiVersion: v1
 metadata:
   name: rsyslog-relp-tls-v1
   namespace: garden-foo
+immutable: true
 data:
   ca: |
     -----BEGIN BEGIN RSA PRIVATE KEY-----

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -123,11 +123,11 @@ loggingRules:
 
 ### Securing the Communication to the Target Server with TLS
 
-The communication to the target server is not encrypted by default. To enable encryption, set the `.tls.enabled` field in the `shoot-rsyslog-relp` extension configuration to `true`. In this case, a immutable secret which contains the TLS certificates used to establish the TLS connection to the server must be created in the same project namespace as your Shoot.
+The communication to the target server is not encrypted by default. To enable encryption, set the `.tls.enabled` field in the `shoot-rsyslog-relp` extension configuration to `true`. In this case, an immutable secret which contains the TLS certificates used to establish the TLS connection to the server must be created in the same project namespace as your Shoot.
 
 An example Secret is given below:
 
-> **Note:**  The secret should be immutable
+> **Note:**  The secret must be immutable
 
 ```yaml
 kind: Secret

--- a/example/secret-rsyslog-tls-certs.yaml
+++ b/example/secret-rsyslog-tls-certs.yaml
@@ -8,6 +8,7 @@ apiVersion: v1
 metadata:
   name: rsyslog-relp-tls
   namespace: garden-local
+immutable: true
 stringData:
   ca: |
     -----BEGIN CERTIFICATE-----

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -222,7 +222,7 @@ tls:
 								Name:      "rsyslog-secret",
 								Namespace: "bar",
 							},
-							Immutable: pointer.Bool(true),
+							Immutable: ptr.To(true),
 							Data: map[string][]byte{
 								"ca":  []byte("data"),
 								"crt": []byte("data"),

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -222,6 +222,7 @@ tls:
 								Name:      "rsyslog-secret",
 								Namespace: "bar",
 							},
+							Immutable: pointer.Bool(true),
 							Data: map[string][]byte{
 								"ca":  []byte("data"),
 								"crt": []byte("data"),

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener-extension-shoot-rsyslog-relp/pkg/constants"
@@ -34,7 +35,7 @@ func ValidateRsyslogRelpSecret(secret *corev1.Secret) error {
 	if _, ok := secret.Data[constants.RsyslogPrivateKeyKey]; !ok {
 		return fmt.Errorf("secret %s is missing %s value", key.String(), constants.RsyslogPrivateKeyKey)
 	}
-	if secret.Immutable == nil || !*secret.Immutable {
+	if !ptr.Deref(secret.Immutable, false) {
 		return fmt.Errorf("secret %s should be immutable", key.String())
 	}
 	if len(secret.Data) != 3 {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -36,7 +36,7 @@ func ValidateRsyslogRelpSecret(secret *corev1.Secret) error {
 		return fmt.Errorf("secret %s is missing %s value", key.String(), constants.RsyslogPrivateKeyKey)
 	}
 	if !ptr.Deref(secret.Immutable, false) {
-		return fmt.Errorf("secret %s should be immutable", key.String())
+		return fmt.Errorf("secret %s must be immutable", key.String())
 	}
 	if len(secret.Data) != 3 {
 		return fmt.Errorf("secret %s should have only three data entries", key.String())

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -34,6 +34,9 @@ func ValidateRsyslogRelpSecret(secret *corev1.Secret) error {
 	if _, ok := secret.Data[constants.RsyslogPrivateKeyKey]; !ok {
 		return fmt.Errorf("secret %s is missing %s value", key.String(), constants.RsyslogPrivateKeyKey)
 	}
+	if secret.Immutable == nil || !*secret.Immutable {
+		return fmt.Errorf("secret %s should be immutable", key.String())
+	}
 	if len(secret.Data) != 3 {
 		return fmt.Errorf("secret %s should have only three data entries", key.String())
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Utils", func() {
 		Entry(
 			"should return error if secret is mutable",
 			[]byte("caData"), []byte("crtData"), []byte("tlsData"), []byte("extraData"), false,
-			MatchError(ContainSubstring("secret foo/rsyslog-secret should be immutable")),
+			MatchError(ContainSubstring("secret foo/rsyslog-secret must be immutable")),
 		),
 	)
 })

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Utils", func() {
 	})
 
 	DescribeTable("#ValidateRsyslogRelpSecret",
-		func(caData, crtData, keyData, extraData []byte, matcher types.GomegaMatcher) {
+		func(caData, crtData, keyData, extraData []byte, immutable bool, matcher types.GomegaMatcher) {
 			var data = map[string][]byte{}
 
 			if len(caData) > 0 {
@@ -43,35 +43,41 @@ var _ = Describe("Utils", func() {
 					Name:      "rsyslog-secret",
 					Namespace: "foo",
 				},
-				Data: data,
+				Immutable: &immutable,
+				Data:      data,
 			}
 
 			Expect(ValidateRsyslogRelpSecret(secret)).To(matcher)
 		},
 		Entry(
 			"should return error if secret does not contain 'ca' data entry",
-			nil, nil, nil, nil,
+			nil, nil, nil, nil, true,
 			MatchError(ContainSubstring("secret foo/rsyslog-secret is missing ca value")),
 		),
 		Entry(
 			"should return error if secret does not contain 'crt' data entry",
-			[]byte("caData"), nil, nil, nil,
+			[]byte("caData"), nil, nil, nil, true,
 			MatchError(ContainSubstring("secret foo/rsyslog-secret is missing crt value")),
 		),
 		Entry(
 			"should return error if secret does not contain 'key' data entry",
-			[]byte("caData"), []byte("crtData"), nil, nil,
+			[]byte("caData"), []byte("crtData"), nil, nil, true,
 			MatchError(ContainSubstring("secret foo/rsyslog-secret is missing key value")),
 		),
 		Entry(
 			"should not return error if secret is valid",
-			[]byte("caData"), []byte("crtData"), []byte("keyData"), nil,
+			[]byte("caData"), []byte("crtData"), []byte("keyData"), nil, true,
 			Succeed(),
 		),
 		Entry(
 			"should return error if secret does not contain 'tls' data entry",
-			[]byte("caData"), []byte("crtData"), []byte("tlsData"), []byte("extraData"),
+			[]byte("caData"), []byte("crtData"), []byte("tlsData"), []byte("extraData"), true,
 			MatchError(ContainSubstring("secret foo/rsyslog-secret should have only three data entries")),
+		),
+		Entry(
+			"should return error if secret is mutable",
+			[]byte("caData"), []byte("crtData"), []byte("tlsData"), []byte("extraData"), false,
+			MatchError(ContainSubstring("secret foo/rsyslog-secret should be immutable")),
 		),
 	)
 })

--- a/pkg/webhook/operatingsystemconfig/ensurer.go
+++ b/pkg/webhook/operatingsystemconfig/ensurer.go
@@ -70,7 +70,7 @@ func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gctx gcontext.Garde
 		}
 	}
 
-	rsyslogFiles, err := getRsyslogFiles(ctx, e.client, extension.Namespace, shootRsyslogRelpConfig, cluster)
+	rsyslogFiles, err := getRsyslogFiles(shootRsyslogRelpConfig, cluster)
 	if err != nil {
 		return err
 	}

--- a/pkg/webhook/operatingsystemconfig/rsyslog.go
+++ b/pkg/webhook/operatingsystemconfig/rsyslog.go
@@ -221,14 +221,6 @@ func getRsyslogTLSFiles(ctx context.Context, c client.Client, cluster *extension
 		return nil, fmt.Errorf("failed to find referenced resource with name %s and kind Secret", secretRefName)
 	}
 
-	// TODO(plkokanov): Remove this validation once the referenced secret in the project in
-	// the garden cluster is forced to be immutable. In that case updating the secret will require
-	// creating a new secret object and editing the shoot.spec.resources to refer to that new secret.
-	// This will trigger the secret validation in the shoot-rsyslog-relp admission.
-	if err := validateReferencedSecret(ctx, c, ref, secretRefName, namespace); err != nil {
-		return nil, fmt.Errorf("referenced secret is not valid: %w", err)
-	}
-
 	refSecretName := v1beta1constants.ReferencedResourcesPrefix + ref.ResourceRef.Name
 	return []extensionsv1alpha1.File{
 		{

--- a/pkg/webhook/operatingsystemconfig/rsyslog.go
+++ b/pkg/webhook/operatingsystemconfig/rsyslog.go
@@ -6,7 +6,6 @@ package operatingsystemconfig
 
 import (
 	"bytes"
-	"context"
 	_ "embed"
 	"fmt"
 	"strconv"
@@ -15,15 +14,11 @@ import (
 
 	"github.com/Masterminds/sprig"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener-extension-shoot-rsyslog-relp/pkg/apis/rsyslog"
 	"github.com/gardener/gardener-extension-shoot-rsyslog-relp/pkg/constants"
@@ -289,18 +284,4 @@ func computeLogFilters(loggingRules []rsyslog.LoggingRule) []string {
 	}
 
 	return filters
-}
-
-func validateReferencedSecret(ctx context.Context, c client.Client, ref *gardencorev1beta1.NamedResourceReference, secretRefName, namespace string) error {
-	refSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      ref.ResourceRef.Name,
-			Namespace: namespace,
-		},
-	}
-	if err := extensionscontroller.GetObjectByReference(ctx, c, &ref.ResourceRef, namespace, refSecret); err != nil {
-		return fmt.Errorf("failed to read referenced secret %s%s for reference %s", v1beta1constants.ReferencedResourcesPrefix, ref.ResourceRef.Name, secretRefName)
-	}
-
-	return utils.ValidateRsyslogRelpSecret(refSecret)
 }

--- a/pkg/webhook/operatingsystemconfig/rsyslog.go
+++ b/pkg/webhook/operatingsystemconfig/rsyslog.go
@@ -105,14 +105,14 @@ func init() {
 	}
 }
 
-func getRsyslogFiles(ctx context.Context, c client.Client, namespace string, rsyslogRelpConfig *rsyslog.RsyslogRelpConfig, cluster *extensionscontroller.Cluster) ([]extensionsv1alpha1.File, error) {
+func getRsyslogFiles(rsyslogRelpConfig *rsyslog.RsyslogRelpConfig, cluster *extensionscontroller.Cluster) ([]extensionsv1alpha1.File, error) {
 	var rsyslogFiles []extensionsv1alpha1.File
 
 	rsyslogValues := getRsyslogValues(rsyslogRelpConfig, cluster)
 
 	if rsyslogRelpConfig.TLS != nil && rsyslogRelpConfig.TLS.Enabled {
 		rsyslogValues["tls"] = getRsyslogTLSValues(rsyslogRelpConfig)
-		rsyslogTLSFiles, err := getRsyslogTLSFiles(ctx, c, cluster, *rsyslogRelpConfig.TLS.SecretReferenceName, namespace)
+		rsyslogTLSFiles, err := getRsyslogTLSFiles(cluster, *rsyslogRelpConfig.TLS.SecretReferenceName)
 		if err != nil {
 			return nil, err
 		}
@@ -215,7 +215,7 @@ func getRsyslogTLSValues(rsyslogRelpConfig *rsyslog.RsyslogRelpConfig) map[strin
 	}
 }
 
-func getRsyslogTLSFiles(ctx context.Context, c client.Client, cluster *extensionscontroller.Cluster, secretRefName, namespace string) ([]extensionsv1alpha1.File, error) {
+func getRsyslogTLSFiles(cluster *extensionscontroller.Cluster, secretRefName string) ([]extensionsv1alpha1.File, error) {
 	ref := v1beta1helper.GetResourceByName(cluster.Shoot.Spec.Resources, secretRefName)
 	if ref == nil || ref.ResourceRef.Kind != "Secret" {
 		return nil, fmt.Errorf("failed to find referenced resource with name %s and kind Secret", secretRefName)

--- a/test/common/testdata/tls/rsyslog-relp-secret.yaml
+++ b/test/common/testdata/tls/rsyslog-relp-secret.yaml
@@ -8,6 +8,7 @@ apiVersion: v1
 metadata:
   name: rsyslog-relp-tls
   namespace: garden-local
+immutable: true
 stringData:
   ca: |
     -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
This PR forces referenced tls secret resource to be immutable by rejecting shoot config if mutable

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/issues/2

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
When changing referenced TLS secret in `shoot.spec.resources[]` the user should provide only immutable secret
```
