### PR TITLE
Fix ocm repository mapping for head updates

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -7,20 +7,14 @@ gardener-extension-shoot-rsyslog-relp:
     traits:
       version:
         preprocess: 'inject-commit-hash'
-      component_descriptor:
-        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
   jobs:
     head-update:
       traits:
-        draft_release: ~
-        options:
-          public_build_logs: true
-    pull-request:
-      traits:
-        pull-request: ~
         component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
           ocm_repository_mappings:
             - repository: europe-docker.pkg.dev/gardener-project/releases
+        draft_release: ~
         options:
           public_build_logs: true
     release:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ EXTENSION_PREFIX            := gardener-extension
 NAME                        := shoot-rsyslog-relp
 NAME_ADMISSION              := $(NAME)-admission
 NAME_ECHO_SERVER            := $(NAME)-echo-server
-IMAGE                       := europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/shoot-rsyslog-relp
+IMAGE                       := europe-docker.pkg.dev/gardener-project/public/gardener/extensions/shoot-rsyslog-relp
+ECHO_SERVER_IMAGE           := europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/$(NAME_ECHO_SERVER)
 REPO_ROOT                   := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 HACK_DIR                    := $(REPO_ROOT)/hack
 VERSION                     := $(shell cat "$(REPO_ROOT)/VERSION")
@@ -57,7 +58,7 @@ docker-images:
 
 .PHONY: echo-server-docker-image
 echo-server-docker-image:
-	@docker build --platform linux/amd64,linux/arm64 --build-arg EFFECTIVE_VERSION=$(ECHO_SERVER_VERSION) -t $(IMAGE)-echo-server:$(ECHO_SERVER_VERSION) -t $(IMAGE)-echo-server:latest -f Dockerfile -m 6g --target $(NAME_ECHO_SERVER) .
+	@docker build --platform linux/amd64,linux/arm64 --build-arg EFFECTIVE_VERSION=$(ECHO_SERVER_VERSION) -t $(ECHO_SERVER_IMAGE):$(ECHO_SERVER_VERSION) -t $(ECHO_SERVER_IMAGE):latest -f Dockerfile -m 6g --target $(NAME_ECHO_SERVER) .
 
 .PHONY: push-echo-server-image
 push-echo-server-image:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # [Gardener Extension to configure rsyslog with relp module](https://gardener.cloud)
 
 [![REUSE status](https://api.reuse.software/badge/github.com/gardener/gardener-extension-shoot-rsyslog-relp)](https://api.reuse.software/info/github.com/gardener/gardener-extension-shoot-rsyslog-relp)
+[![CI Build status](https://concourse.ci.gardener.cloud/api/v1/teams/gardener-tests/pipelines/gardener-extension-shoot-rsyslog-relp-main/jobs/main-head-update-job/badge)](https://concourse.ci.gardener.cloud/teams/gardener-tests/pipelines/gardener-extension-shoot-rsyslog-relp-main/jobs/main-head-update-job)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gardener/gardener-extension-shoot-rsyslog-relp)](https://goreportcard.com/report/github.com/gardener/gardener-extension-shoot-rsyslog-relp)
 
 Gardener extension controller which configures the rsyslog and auditd services installed on shoot nodes.

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -75,7 +75,7 @@ The [testmachinery tests](../../test/testmachinery/shoot/) use an `rsyslog-relp-
 Sometimes it might be necessary to update the image and publish it, e.g. when updating the `alpine` base image version specified in the repository's [Dokerfile](../../Dockerfile#L34).
 
 To do that:
-1. Bump the version with which the image is built in the [Makefile](../../Makefile#L14).
+1. Bump the version with which the image is built in the [Makefile](../../Makefile#L15).
 1. Build the `shoot-rsyslog-relp-echo-server` image:
    ```bash
    make echo-server-docker-image


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
This PR fixes the component descriptor generation for head updates. The images for the `shoot-rsyslog-relp` extension components head updates are built by prow, however we still need to generate the component descriptor properly in concourse. The pull-request job is removed, as this is also handled in prow.

The PR additionally separates the repositories of the `shoot-rsyslog-relp`, `shoot-rsyslog-relp-admission` and `shoot-rsyslog-relp-echo-server` images in the `Makefile`. For the former two we use `europe-docker.pkg.dev/gardener-project/public/gardener/extensions` it is readonly and we can prevent accidental pushes of images created locally. For the latter we continue to use `europe-docker.pkg.dev/gardener-project/releases/gardener/extensions`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @ccwienk 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
