### PR TITLE
Always delete the config cleaner MR when the extension is deleted

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -161,9 +161,12 @@ func cleanRsyslogRelpConfiguration(ctx context.Context, cluster *extensionscontr
 	}
 	cleaner := rsyslogrelpconfigcleaner.New(client, namespace, values)
 
-	// If the Shoot is in deletion, then there is no need to deploy the component to clean up
-	// the rsyslog configuration from Nodes. However, we should still try to destroy the
-	// configuration cleaner component, in case it was unsuccessfully deployed in a previous reconciliation
+	// If the Shoot is in deletion, then there is no need to deploy the component to clean up the rsyslog
+	// configuration from Nodes. The Shoot deletion flow ensures that the Worker is deleted before
+	// the Extension deletion. Hence, there are no Nodes, no need to deploy the configuration cleaner component.
+	//
+	// However, we should still try to destroy the
+	// configuration cleaner component, in case it failed to be cleaned up in a previous reconciliation
 	// where the extension was deleted before the shoot deletion was triggered.
 	if cluster.Shoot.DeletionTimestamp == nil {
 		if err := component.OpWait(cleaner).Deploy(ctx); err != nil {

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -96,13 +96,6 @@ func (a *actuator) Delete(ctx context.Context, _ logr.Logger, ex *extensionsv1al
 		return err
 	}
 
-	// If the Shoot is in deletion, then there is no need to clean up the rsyslog configuration from Nodes.
-	// The Shoot deletion flow ensures that the Worker is deleted before the Extension deletion.
-	// Hence, there are no Nodes, no need to clean up rsyslog configuration.
-	if cluster.Shoot.DeletionTimestamp != nil {
-		return nil
-	}
-
 	return cleanRsyslogRelpConfiguration(ctx, cluster, a.client, namespace)
 }
 
@@ -168,8 +161,14 @@ func cleanRsyslogRelpConfiguration(ctx context.Context, cluster *extensionscontr
 	}
 	cleaner := rsyslogrelpconfigcleaner.New(client, namespace, values)
 
-	if err := component.OpWait(cleaner).Deploy(ctx); err != nil {
-		return fmt.Errorf("failed to deploy the rsyslog relp configuration cleaner component: %w", err)
+	// If the Shoot is in deletion, then there is no need to deploy the component to clean up
+	// the rsyslog configuration from Nodes. However, we should still try to destroy the
+	// configuration cleaner component, in case it was unsuccessfully deployed in a previous reconciliation
+	// where the extension was deleted before the shoot deletion was triggered.
+	if cluster.Shoot.DeletionTimestamp == nil {
+		if err := component.OpWait(cleaner).Deploy(ctx); err != nil {
+			return fmt.Errorf("failed to deploy the rsyslog relp configuration cleaner component: %w", err)
+		}
 	}
 
 	if err := component.OpDestroyAndWait(cleaner).Destroy(ctx); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue in which the `extension-shoot-rsyslog-relp-configuration-cleaner` ManagedResource could prevent a shoot cluster from being deleted. The issue could happen like this:
1. Create a shoot cluster with the `shoot-rsyslog-relp` extension enabled
2. Disable the extension, which would cause the `extension-shoot-rsyslog-relp-configuration-cleaner` MR to get deployed
3. Force an error to occur during after the deployment of the MR is finished, but before it has become ready.
4. Delete the shoot cluster

When the reconciliation of the `shoot-rsyslog-relp` extension is restarted while the shoot cluster is being deleted, it will exit early [here](https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/blob/83bfaddbd8080a03818e42459b7c927a90938dfb/pkg/controller/lifecycle/actuator.go#L99-L104)
This means that the code which should trigger the deletion of the MR [here](https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/blob/83bfaddbd8080a03818e42459b7c927a90938dfb/pkg/controller/lifecycle/actuator.go#L175-L177) never gets executed.

In the end the MR is orphaned and blocks shoot deletion.

---

To fix the issue we now only skip the deployment and waiting for the `extension-shoot-rsyslog-relp-configuration-cleaner` MR to become ready if the shoot is being deleted. This MR is not necessary in that case as the nodes will get deleted anyway. Additionally, due to various problems, waiting for the MR to become ready might block shoot deletion.
The deletion of the MR is done in all cases now.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
6. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed an issue where the `extension-shoot-rsyslog-relp-configuration-cleaner` ManagedResource could block Shoot deletion if the `shoot-rsyslog-relp` was disabled before the Shoot deletion was triggered, and disabling the extension failed while trying to deploy the said ManagedResource and wait for it to become ready. 
```
