### PR TITLE
Increase timeouts for `testmachinery` tests

### DIFF
--- a/test/common/configuration.go
+++ b/test/common/configuration.go
@@ -122,13 +122,13 @@ func WithTarget(target string) func(rsyslogRelpConfig *rsyslogv1alpha1.RsyslogRe
 	}
 }
 
-// WithTLSWithSecretRefName returns a function which enables TLS for the rsyslog relp configuration and sets
-// the tls.secretRefName to the given secretRefName.
-func WithTLSWithSecretRefName(secretRefName string) func(rsyslogRelpConfig *rsyslogv1alpha1.RsyslogRelpConfig) {
+// WithTLSWithSecretRefNameAndTLSLib returns a function which enables TLS for the rsyslog relp configuration and sets
+// the tls.secretRefName to the given secretRefName and tls.tlsLib to the given tlsLib.
+func WithTLSWithSecretRefNameAndTLSLib(secretRefName, tlsLib string) func(rsyslogRelpConfig *rsyslogv1alpha1.RsyslogRelpConfig) {
 	return func(rsyslogRelpConfig *rsyslogv1alpha1.RsyslogRelpConfig) {
 		var (
 			authModeName  = rsyslogv1alpha1.AuthMode("name")
-			tlsLibOpenSSL = rsyslogv1alpha1.TLSLib("openssl")
+			tlsLibOpenSSL = rsyslogv1alpha1.TLSLib(tlsLib)
 		)
 
 		rsyslogRelpConfig.TLS = &rsyslogv1alpha1.TLS{

--- a/test/common/verifier.go
+++ b/test/common/verifier.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"time"
+	"strings"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/test/framework"
@@ -31,6 +31,11 @@ type Verifier struct {
 	shootName                  string
 	shootUID                   string
 	rootPodExecutor            framework.RootPodExecutor
+
+	// optional fields
+	consistentlyArgs []interface{}
+	eventuallyArgs   []interface{}
+	providerType     string
 }
 
 // NewVerifier creates a new Verifier.
@@ -49,6 +54,27 @@ func NewVerifier(log logr.Logger,
 	}
 }
 
+// WithConsistentlyArgs specifies the arguments to pass to
+// `Consistently` calls made by the Verifier.
+func (v *Verifier) WithConsistentlyArgs(args ...interface{}) *Verifier {
+	v.consistentlyArgs = args
+	return v
+}
+
+// WithEventuallyArgs specifies the arguments to pass to
+// `Eventually` calls made by the Verifier.
+func (v *Verifier) WithEventuallyArgs(args ...interface{}) *Verifier {
+	v.eventuallyArgs = args
+	return v
+}
+
+// WithShootProviderType specifies the provider type of
+// the shoot currently used for the tests.
+func (v *Verifier) WithShootProviderType(providerType string) *Verifier {
+	v.providerType = providerType
+	return v
+}
+
 // SetEchoServerPodIfAndName sets the clientcorev1.PodInterface and the name of the rsyslog-relp-echo-server pod to the Verifier.
 func (v *Verifier) SetEchoServerPodIfAndName(echoServerPodIf clientcorev1.PodInterface, echoServerPodName string) {
 	v.rsyslogRelpEchoServerPodIf = echoServerPodIf
@@ -61,7 +87,7 @@ func (v *Verifier) VerifyExtensionForNode(ctx context.Context, nodeName string) 
 	v.setPodExecutor(framework.NewRootPodExecutor(v.log, v.client, &nodeName, "kube-system"))
 	v.setNodeName(nodeName)
 
-	v.verifyThatRsyslogIsActiveAndConfigured(ctx, 5*time.Second, 20*time.Second)
+	v.verifyThatRsyslogIsActiveAndConfigured(ctx)
 	v.verifyThatLogsAreSentToEchoServer(ctx, "test-program", "1", "this should get sent to echo server")
 	v.verifyThatLogsAreNotSentToEchoServer(ctx, "other-program", "1", "this should not get sent to echo server")
 	v.verifyThatLogsAreNotSentToEchoServer(ctx, "test-program", "3", "this should not get sent to echo server")
@@ -94,30 +120,30 @@ func (v *Verifier) setNodeName(nodeName string) {
 	v.nodeName = nodeName
 }
 
-func (v *Verifier) verifyThatRsyslogIsActiveAndConfigured(ctx context.Context, pollInterval, timeout time.Duration) {
-	EventuallyWithOffset(2, ctx, func(g Gomega) {
+func (v *Verifier) verifyThatRsyslogIsActiveAndConfigured(ctx context.Context) {
+	EventuallyWithOffset(2, func(g Gomega) {
 		response, _ := ExecCommand(ctx, v.log, v.rootPodExecutor, "systemctl is-active rsyslog.service &>/dev/null && echo 'active' || echo 'not active'")
 		g.Expect(string(response)).To(Equal("active\n"), fmt.Sprintf("Expected the rsyslog.service unit to be active on node %s", v.nodeName))
 
 		response, _ = ExecCommand(ctx, v.log, v.rootPodExecutor, "test -f /etc/rsyslog.d/60-audit.conf && echo 'configured' || echo 'not configured'")
 		g.Expect(string(response)).To(Equal("configured\n"), fmt.Sprintf("Expected the /etc/rsyslog.d/60-audit.conf file to exist on node %s", v.nodeName))
-	}).WithTimeout(timeout).WithPolling(pollInterval).Should(Succeed())
+	}, v.eventuallyArgs...).WithContext(ctx).Should(Succeed())
 }
 
 func (v *Verifier) verifyThatLogsAreSentToEchoServer(ctx context.Context, programName, severity, logMessage string) {
-	EventuallyWithOffset(2, ctx, func(g Gomega) {
+	EventuallyWithOffset(2, func(g Gomega) {
 		logLines, err := v.generateAndGetLogs(ctx, programName, severity, logMessage)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(logLines).To(ContainElement(MatchRegexp(v.constructRegex(programName, logMessage))))
-	}).Should(Succeed(), fmt.Sprintf("Expected to successfully generate logs for node %s and logs to be present in rsyslog-relp-echo-server", v.nodeName))
+	}, v.eventuallyArgs...).WithContext(ctx).Should(Succeed(), fmt.Sprintf("Expected to successfully generate logs for node %s and logs to be present in rsyslog-relp-echo-server", v.nodeName))
 }
 
 func (v *Verifier) verifyThatLogsAreNotSentToEchoServer(ctx context.Context, programName, severity, logMessage string) {
-	ConsistentlyWithOffset(2, ctx, func(g Gomega) {
+	ConsistentlyWithOffset(2, func(g Gomega) {
 		logLines, err := v.generateAndGetLogs(ctx, programName, severity, logMessage)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(logLines).NotTo(ContainElement(MatchRegexp(v.constructRegex(programName, logMessage))))
-	}).Should(Succeed(), fmt.Sprintf("Expected to successfully generate logs for node %s and logs to NOT be present in rsyslog-relp-echo-server", v.nodeName))
+	}, v.consistentlyArgs...).WithContext(ctx).Should(Succeed(), fmt.Sprintf("Expected to successfully generate logs for node %s and logs to NOT be present in rsyslog-relp-echo-server", v.nodeName))
 }
 
 func (v *Verifier) generateAndGetLogs(ctx context.Context, programName, severity, logMessage string) ([]string, error) {
@@ -140,5 +166,19 @@ func (v *Verifier) generateAndGetLogs(ctx context.Context, programName, severity
 }
 
 func (v *Verifier) constructRegex(programName, logMessage string) string {
-	return fmt.Sprintf(` %s %s %s .* %s\[\d+\]: .* %s`, v.projectName, v.shootName, v.shootUID, programName, logMessage)
+	expectedNodeHostName := v.nodeName
+	switch {
+	case v.providerType == "aws":
+		// On aws the the nodes ara named by adding the regional domain name after the instance, e.g.:
+		// `ip-xxx-xxx-xxx-xxx.ec2.<region>.internal`. However the rsyslog `hostname` property only returns the
+		// instance name - `ip-xxx-xxx-xxx-xxx`.
+		expectedNodeHostName = strings.SplitN(v.nodeName, ".", 2)[0]
+	case v.providerType == "alicloud":
+		// On alicloud the name of a node is made of lower case characters, e.g. `izgw846obiag360olq8sdaz`.
+		// However, the rsyslog `hostname` property can also contain upper case characters, e.g. `iZgw846obiag360olq8sdaZ`.
+		// This is why we use the (?i:...) - to turn on case-insensitive mode for the hostname matching.
+		expectedNodeHostName = "(?i:" + expectedNodeHostName + ")"
+	}
+
+	return fmt.Sprintf(`%s %s %s %s \d+ %s\[\d+\]: .* %s`, v.projectName, v.shootName, v.shootUID, expectedNodeHostName, programName, logMessage)
 }

--- a/test/e2e/create_enable_disable_delete.go
+++ b/test/e2e/create_enable_disable_delete.go
@@ -53,9 +53,7 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 
 			echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootFramework.SeedClient)
 			Expect(err).NotTo(HaveOccurred())
-			verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, echoServerPodIf, echoServerPodName, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID)).
-				WithConsistentlyArgs(20*time.Second, 10*time.Second).
-				WithEventuallyArgs(20*time.Second, 5*time.Second)
+			verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, echoServerPodIf, echoServerPodName, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID))
 
 			common.ForEachNode(ctx, f.ShootFramework.ShootClient, func(ctx context.Context, node *corev1.Node) {
 				verifier.VerifyExtensionForNode(ctx, node.Name)

--- a/test/e2e/create_enable_force_delete.go
+++ b/test/e2e/create_enable_force_delete.go
@@ -46,9 +46,7 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 
 		echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootFramework.SeedClient)
 		Expect(err).NotTo(HaveOccurred())
-		verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, echoServerPodIf, echoServerPodName, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID)).
-			WithConsistentlyArgs(20*time.Second, 10*time.Second).
-			WithEventuallyArgs(20*time.Second, 5*time.Second)
+		verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, echoServerPodIf, echoServerPodName, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID))
 
 		common.ForEachNode(ctx, f.ShootFramework.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)

--- a/test/e2e/create_enable_force_delete.go
+++ b/test/e2e/create_enable_force_delete.go
@@ -46,7 +46,9 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 
 		echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootFramework.SeedClient)
 		Expect(err).NotTo(HaveOccurred())
-		verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, echoServerPodIf, echoServerPodName, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID))
+		verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, echoServerPodIf, echoServerPodName, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID)).
+			WithConsistentlyArgs(20*time.Second, 10*time.Second).
+			WithEventuallyArgs(20*time.Second, 5*time.Second)
 
 		common.ForEachNode(ctx, f.ShootFramework.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)

--- a/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
+++ b/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
@@ -45,9 +45,7 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 
 		echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootFramework.SeedClient)
 		Expect(err).NotTo(HaveOccurred())
-		verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, echoServerPodIf, echoServerPodName, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID)).
-			WithConsistentlyArgs(20*time.Second, 10*time.Second).
-			WithEventuallyArgs(20*time.Second, 5*time.Second)
+		verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, echoServerPodIf, echoServerPodName, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID))
 
 		common.ForEachNode(ctx, f.ShootFramework.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)

--- a/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
+++ b/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
@@ -45,7 +45,9 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 
 		echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootFramework.SeedClient)
 		Expect(err).NotTo(HaveOccurred())
-		verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, echoServerPodIf, echoServerPodName, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID))
+		verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, echoServerPodIf, echoServerPodName, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID)).
+			WithConsistentlyArgs(20*time.Second, 10*time.Second).
+			WithEventuallyArgs(20*time.Second, 5*time.Second)
 
 		common.ForEachNode(ctx, f.ShootFramework.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)

--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -38,11 +38,14 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 		Expect(f.UpdateShoot(ctx, shootMutateFn)).To(Succeed())
 
 		By("Verify shoot-rsyslog-relp works")
-		ctx, cancel = context.WithTimeout(parentCtx, 2*time.Minute)
+		ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)
 		defer cancel()
 		echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootClient)
 		Expect(err).NotTo(HaveOccurred())
-		verifier := common.NewVerifier(f.Logger, f.ShootClient, echoServerPodIf, echoServerPodName, f.Project.Name, f.Shoot.Name, string(f.Shoot.UID))
+		verifier := common.NewVerifier(f.Logger, f.ShootClient, echoServerPodIf, echoServerPodName, f.Project.Name, f.Shoot.Name, string(f.Shoot.UID)).
+			WithConsistentlyArgs(30*time.Second, 10*time.Second).
+			WithEventuallyArgs(1*time.Minute, 10*time.Second).
+			WithShootProviderType(f.Shoot.Spec.Provider.Type)
 
 		common.ForEachNode(ctx, f.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)
@@ -57,7 +60,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 		})).To(Succeed())
 
 		By("Verify that shoot-rsyslog-relp extension is disabled")
-		ctx, cancel = context.WithTimeout(parentCtx, 2*time.Minute)
+		ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)
 		DeferCleanup(cancel)
 		common.ForEachNode(ctx, f.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionDisabledForNode(ctx, node.Name)
@@ -94,9 +97,8 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 
 	})
 
-	Context("shoot-rsyslog-relp extension with tls enabled", Label("tls-enabled"), func() {
+	Context("shoot-rsyslog-relp extension with tls and openssl enabled", Label("tls-openssl-enabled"), func() {
 		const secretReferenceName = "rsyslog-relp-tls"
-
 		var createdResources []client.Object
 
 		f.Serial().Beta().CIt("should enable and disable the shoot-rsyslog-relp extension", func(parentCtx context.Context) {
@@ -109,7 +111,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			test(parentCtx, func(shoot *gardencorev1beta1.Shoot) error {
-				common.AddOrUpdateRsyslogRelpExtension(shoot, common.WithPort(443), common.WithTLSWithSecretRefName(secretReferenceName), common.WithTarget(echoServerIP))
+				common.AddOrUpdateRsyslogRelpExtension(shoot, common.WithPort(443), common.WithTLSWithSecretRefNameAndTLSLib(secretReferenceName, "openssl"), common.WithTarget(echoServerIP))
 				common.AddOrUpdateRsyslogTLSSecretResource(shoot, secretReferenceName)
 				return nil
 			})

--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -42,10 +42,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 		defer cancel()
 		echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootClient)
 		Expect(err).NotTo(HaveOccurred())
-		verifier := common.NewVerifier(f.Logger, f.ShootClient, echoServerPodIf, echoServerPodName, f.Project.Name, f.Shoot.Name, string(f.Shoot.UID)).
-			WithConsistentlyArgs(30*time.Second, 10*time.Second).
-			WithEventuallyArgs(1*time.Minute, 10*time.Second).
-			WithShootProviderType(f.Shoot.Spec.Provider.Type)
+		verifier := common.NewVerifier(f.Logger, f.ShootClient, echoServerPodIf, echoServerPodName, f.Shoot.Spec.Provider.Type, f.Project.Name, f.Shoot.Name, string(f.Shoot.UID))
 
 		common.ForEachNode(ctx, f.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)

--- a/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
+++ b/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
@@ -48,10 +48,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 
 		echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootClient)
 		Expect(err).NotTo(HaveOccurred())
-		verifier := common.NewVerifier(f.Logger, f.ShootClient, echoServerPodIf, echoServerPodName, f.Project.Name, f.Shoot.Name, string(f.Shoot.UID)).
-			WithConsistentlyArgs(30*time.Second, 10*time.Second).
-			WithEventuallyArgs(1*time.Minute, 10*time.Second).
-			WithShootProviderType(f.Shoot.Spec.Provider.Type)
+		verifier := common.NewVerifier(f.Logger, f.ShootClient, echoServerPodIf, echoServerPodName, f.Shoot.Spec.Provider.Type, f.Project.Name, f.Shoot.Name, string(f.Shoot.UID))
 
 		common.ForEachNode(ctx, f.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)

--- a/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
+++ b/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
@@ -43,11 +43,15 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 		})).To(Succeed())
 
 		By("Verify shoot-rsyslog-relp works")
-		ctx, cancel = context.WithTimeout(parentCtx, 2*time.Minute)
+		ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)
 		defer cancel()
+
 		echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootClient)
 		Expect(err).NotTo(HaveOccurred())
-		verifier := common.NewVerifier(f.Logger, f.ShootClient, echoServerPodIf, echoServerPodName, f.Project.Name, f.Shoot.Name, string(f.Shoot.UID))
+		verifier := common.NewVerifier(f.Logger, f.ShootClient, echoServerPodIf, echoServerPodName, f.Project.Name, f.Shoot.Name, string(f.Shoot.UID)).
+			WithConsistentlyArgs(30*time.Second, 10*time.Second).
+			WithEventuallyArgs(1*time.Minute, 10*time.Second).
+			WithShootProviderType(f.Shoot.Spec.Provider.Type)
 
 		common.ForEachNode(ctx, f.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)
@@ -73,7 +77,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 		Expect(f.WakeUpShoot(ctx)).To(Succeed())
 
 		By("Verify shoot-rsyslog-relp works after Shoot is woken up")
-		ctx, cancel = context.WithTimeout(parentCtx, 2*time.Minute)
+		ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)
 		defer cancel()
 		echoServerPodIf, echoServerPodName, err = common.GetEchoServerPodInterfaceAndName(ctx, f.ShootClient)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue in the `testmachinery` by increasing their timeout and also adding proper timeout and polling interval arguments to `Eventually` and `Consistnetly` calls.
Additionally, the expected message log that is retrieved from the `rsyslog-relp-echo-server` is now also matched against the hostname of the node from which the message originated.

**Which issue(s) this PR fixes**:
Part of #2 

**Special notes for your reviewer**:
I added an additional option to configure the `tlsLib` setting of the `shoot-rsyslog-relp` extension for local testing purposes. However, I decided to leave it for the future in case we want to create an additional test with `gnutls`. Currently only `openssl` is tested. The reason for that is that certificates have to be generated with an appropriate `cert-tool` as certificates for `openssl` are not compatible with `gnutls` and vice-versa.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
