### PR TITLE
Removes comments at start of audit rules files as they do not work on all OSes

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -24,6 +24,8 @@ Files:
   example/controller-registration.yaml
   hack/api-reference/*.json
   hack/cherry-pick-pull.sh
+  pkg/webhook/operatingsystemconfig/resources/auditrules/*.rules
+  pkg/webhook/operatingsystemconfig/testdata/*.rules
   test/integration/controller/lifecycle/resources/*.yaml
   go.mod
   go.sum

--- a/pkg/webhook/operatingsystemconfig/resources/auditrules/00-base-config.rules
+++ b/pkg/webhook/operatingsystemconfig/resources/auditrules/00-base-config.rules
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
-#
-# SPDX-License-Identifier: Apache-2.0
-
 ## First rule - delete all
 -D
 ## Increase the buffers to survive stress events.

--- a/pkg/webhook/operatingsystemconfig/resources/auditrules/10-privilege-escalation.rules
+++ b/pkg/webhook/operatingsystemconfig/resources/auditrules/10-privilege-escalation.rules
@@ -1,6 +1,2 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
-#
-# SPDX-License-Identifier: Apache-2.0
-
 -a exit,always -F arch=b64 -S setuid -S setreuid -S setgid -S setregid -F auid>0 -F auid!=-1 -F key=privilege_escalation
 -a exit,always -F arch=b64 -S execve -S execveat -F euid=0 -F auid>0 -F auid!=-1 -F key=privilege_escalation

--- a/pkg/webhook/operatingsystemconfig/resources/auditrules/11-privileged-special.rules
+++ b/pkg/webhook/operatingsystemconfig/resources/auditrules/11-privileged-special.rules
@@ -1,5 +1,1 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
-#
-# SPDX-License-Identifier: Apache-2.0
-
 -a exit,always -F arch=b64 -S mount -S mount_setattr -S umount2 -S mknod -S mknodat -S chroot -F auid!=-1 -F key=privileged_special

--- a/pkg/webhook/operatingsystemconfig/resources/auditrules/12-system-integrity.rules
+++ b/pkg/webhook/operatingsystemconfig/resources/auditrules/12-system-integrity.rules
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
-#
-# SPDX-License-Identifier: Apache-2.0
-
 -a exit,always -F dir=/boot -F perm=wa -F key=system_integrity
 -a exit,always -F dir=/etc -F perm=wa -F key=system_integrity
 -a exit,always -F dir=/bin -F perm=wa -F key=system_integrity

--- a/pkg/webhook/operatingsystemconfig/resources/templates/60-audit.conf.tpl
+++ b/pkg/webhook/operatingsystemconfig/resources/templates/60-audit.conf.tpl
@@ -53,6 +53,7 @@ ruleset(name="process_stats") {
 
 ruleset(name="relp_action_ruleset") {
   action(
+    name="rsyslog-relp"
     type="omrelp"
     target="{{ .target }}"
     port="{{ .port }}"

--- a/pkg/webhook/operatingsystemconfig/testdata/00-base-config.rules
+++ b/pkg/webhook/operatingsystemconfig/testdata/00-base-config.rules
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
-#
-# SPDX-License-Identifier: Apache-2.0
-
 ## First rule - delete all
 -D
 ## Increase the buffers to survive stress events.

--- a/pkg/webhook/operatingsystemconfig/testdata/10-privilege-escalation.rules
+++ b/pkg/webhook/operatingsystemconfig/testdata/10-privilege-escalation.rules
@@ -1,6 +1,2 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
-#
-# SPDX-License-Identifier: Apache-2.0
-
 -a exit,always -F arch=b64 -S setuid -S setreuid -S setgid -S setregid -F auid>0 -F auid!=-1 -F key=privilege_escalation
 -a exit,always -F arch=b64 -S execve -S execveat -F euid=0 -F auid>0 -F auid!=-1 -F key=privilege_escalation

--- a/pkg/webhook/operatingsystemconfig/testdata/11-privileged-special.rules
+++ b/pkg/webhook/operatingsystemconfig/testdata/11-privileged-special.rules
@@ -1,5 +1,1 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
-#
-# SPDX-License-Identifier: Apache-2.0
-
 -a exit,always -F arch=b64 -S mount -S mount_setattr -S umount2 -S mknod -S mknodat -S chroot -F auid!=-1 -F key=privileged_special

--- a/pkg/webhook/operatingsystemconfig/testdata/12-system-integrity.rules
+++ b/pkg/webhook/operatingsystemconfig/testdata/12-system-integrity.rules
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
-#
-# SPDX-License-Identifier: Apache-2.0
-
 -a exit,always -F dir=/boot -F perm=wa -F key=system_integrity
 -a exit,always -F dir=/etc -F perm=wa -F key=system_integrity
 -a exit,always -F dir=/bin -F perm=wa -F key=system_integrity

--- a/pkg/webhook/operatingsystemconfig/testdata/60-audit-with-tls.conf
+++ b/pkg/webhook/operatingsystemconfig/testdata/60-audit-with-tls.conf
@@ -51,6 +51,7 @@ ruleset(name="process_stats") {
 
 ruleset(name="relp_action_ruleset") {
   action(
+    name="rsyslog-relp"
     type="omrelp"
     target="localhost"
     port="10250"

--- a/pkg/webhook/operatingsystemconfig/testdata/60-audit.conf
+++ b/pkg/webhook/operatingsystemconfig/testdata/60-audit.conf
@@ -50,6 +50,7 @@ ruleset(name="process_stats") {
 
 ruleset(name="relp_action_ruleset") {
   action(
+    name="rsyslog-relp"
     type="omrelp"
     target="localhost"
     port="10250"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind bug

**What this PR does / why we need it**:
This PR removes the license comments at the start of audit rules files as they do not get properly parsed when `augenrules --load` is invoked 
Additionally it re-adds the name of the `omrelp` action which was regressed in #41 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
