### PR TITLE
Bump golang version to `v1.22.2`

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -20,7 +20,7 @@ gardener-extension-shoot-rsyslog-relp:
     release:
       steps:
         verify:
-          image: 'golang:1.22.0'
+          image: 'golang:1.22.2'
       traits:
         version:
           preprocess: 'finalize'

--- a/.test-defs/TestSuiteShootRsyslogRelpBetaSerial.yaml
+++ b/.test-defs/TestSuiteShootRsyslogRelpBetaSerial.yaml
@@ -22,4 +22,4 @@ spec:
       -ginkgo.focus="\[BETA\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
 
-  image: golang:1.22.0
+  image: golang:1.22.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# builder
-FROM golang:1.22.0 AS builder
+FROM golang:1.22.2 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-shoot-rsyslog-relp
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/gardener-extension-shoot-rsyslog-relp
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind enhancement

**What this PR does / why we need it**:
Bumps golang version to `v1.22.2`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
