### PR TITLE
Avoid audit log duplication when `system-journald-audit` socket is enabled

### DIFF
--- a/pkg/component/rsyslogrelpconfigcleaner/rsyslog_relp_config_cleaner.go
+++ b/pkg/component/rsyslogrelpconfigcleaner/rsyslog_relp_config_cleaner.go
@@ -181,6 +181,12 @@ if [[ -f /host/etc/audit/plugins.d/syslog.conf ]]; then
   sed -i 's/yes/no/g' /host/etc/audit/plugins.d/syslog.conf
 fi
 
+chroot /host /bin/bash -c 'if systemctl list-unit-files systemd-journald-audit.socket > /dev/null; then \
+  systemctl enable systemd-journald-audit.socket; \
+  systemctl start systemd-journald-audit.socket; \
+  systemctl restart systemd-journald; \
+fi'
+
 if [[ -d /host/etc/audit/rules.d.original ]]; then
   if [[ -d /host/etc/audit/rules.d ]]; then
     rm -rf /host/etc/audit/rules.d

--- a/pkg/component/rsyslogrelpconfigcleaner/rsyslog_relp_config_cleaner.go
+++ b/pkg/component/rsyslogrelpconfigcleaner/rsyslog_relp_config_cleaner.go
@@ -178,7 +178,7 @@ func computeCommand() []string {
 fi
 
 if [[ -f /host/etc/audit/plugins.d/syslog.conf ]]; then
-  sed -i 's/yes/no/g' /host/etc/audit/plugins.d/syslog.conf
+  sed -i "s/^active\\>.*/active = no/gi" /host/etc/audit/plugins.d/syslog.conf
 fi
 
 chroot /host /bin/bash -c 'if systemctl list-unit-files systemd-journald-audit.socket > /dev/null; then \

--- a/pkg/component/rsyslogrelpconfigcleaner/rsyslog_relp_config_cleaner.go
+++ b/pkg/component/rsyslogrelpconfigcleaner/rsyslog_relp_config_cleaner.go
@@ -178,7 +178,7 @@ func computeCommand() []string {
 fi
 
 if [[ -f /host/etc/audit/plugins.d/syslog.conf ]]; then
-  sed -i "s/^active\\>.*/active = no/gi" /host/etc/audit/plugins.d/syslog.conf
+  sed -i "s/^active\\>.*/active = no/i" /host/etc/audit/plugins.d/syslog.conf
 fi
 
 chroot /host /bin/bash -c 'if systemctl list-unit-files systemd-journald-audit.socket > /dev/null; then \

--- a/pkg/webhook/operatingsystemconfig/resources/templates/scripts/configure-rsyslog.tpl.sh
+++ b/pkg/webhook/operatingsystemconfig/resources/templates/scripts/configure-rsyslog.tpl.sh
@@ -25,9 +25,11 @@ function configure_auditd() {
     restart_auditd=true
   fi
 
-  if [[ -f {{ .pathSyslogAuditPlugin }} ]] && grep -Fxq "active = no" "{{ .pathSyslogAuditPlugin }}" ; then
-    sed -i 's/no/yes/g' {{ .pathSyslogAuditPlugin }}
-    restart_auditd=true
+  if [[ -f {{ .pathSyslogAuditPlugin }} ]] && \
+      grep -m 1 -qie  "^active\\>" "{{ .pathSyslogAuditPlugin }}" && \
+      ! grep -m 1 -qie "^active\\> = yes" "{{ .pathSyslogAuditPlugin }}" ; then
+    sed -i "s/^active\\>.*/active = yes/gi" {{ .pathSyslogAuditPlugin }}
+    export restart_auditd=true
   fi
 
   if ! systemctl is-active --quiet auditd.service ; then

--- a/pkg/webhook/operatingsystemconfig/resources/templates/scripts/configure-rsyslog.tpl.sh
+++ b/pkg/webhook/operatingsystemconfig/resources/templates/scripts/configure-rsyslog.tpl.sh
@@ -28,7 +28,7 @@ function configure_auditd() {
   if [[ -f {{ .pathSyslogAuditPlugin }} ]] && \
       grep -m 1 -qie  "^active\\>" "{{ .pathSyslogAuditPlugin }}" && \
       ! grep -m 1 -qie "^active\\> = yes" "{{ .pathSyslogAuditPlugin }}" ; then
-    sed -i "s/^active\\>.*/active = yes/gi" {{ .pathSyslogAuditPlugin }}
+    sed -i "s/^active\\>.*/active = yes/i" {{ .pathSyslogAuditPlugin }}
     export restart_auditd=true
   fi
 

--- a/pkg/webhook/operatingsystemconfig/resources/templates/scripts/configure-rsyslog.tpl.sh
+++ b/pkg/webhook/operatingsystemconfig/resources/templates/scripts/configure-rsyslog.tpl.sh
@@ -29,7 +29,7 @@ function configure_auditd() {
       grep -m 1 -qie  "^active\\>" "{{ .pathSyslogAuditPlugin }}" && \
       ! grep -m 1 -qie "^active\\> = yes" "{{ .pathSyslogAuditPlugin }}" ; then
     sed -i "s/^active\\>.*/active = yes/i" {{ .pathSyslogAuditPlugin }}
-    export restart_auditd=true
+    restart_auditd=true
   fi
 
   if ! systemctl is-active --quiet auditd.service ; then

--- a/pkg/webhook/operatingsystemconfig/resources/templates/scripts/configure-rsyslog.tpl.sh
+++ b/pkg/webhook/operatingsystemconfig/resources/templates/scripts/configure-rsyslog.tpl.sh
@@ -13,17 +13,40 @@ function configure_auditd() {
     mv {{ .pathAuditRulesDir }} {{ .pathAuditRulesBackupDir }}
   fi
 
+  restart_auditd=false
+
   if [[ ! -d {{ .pathAuditRulesDir }} ]]; then
     mkdir -p {{ .pathAuditRulesDir }}
   fi
   if ! diff -rq {{ .pathAuditRulesFromOSCDir }} {{ .pathAuditRulesDir }} ; then
     rm -rf {{ .pathAuditRulesDir }}/*
     cp -L {{ .pathAuditRulesFromOSCDir }}/* {{ .pathAuditRulesDir }}/
-    if [[ -f {{ .pathSyslogAuditPlugin }} ]]; then
-      sed -i 's/no/yes/g' {{ .pathSyslogAuditPlugin }}
-    fi
     augenrules --load
-    systemctl restart auditd
+    restart_auditd=true
+  fi
+
+  if [[ -f {{ .pathSyslogAuditPlugin }} ]] && grep -Fxq "active = no" "{{ .pathSyslogAuditPlugin }}" ; then
+    sed -i 's/no/yes/g' {{ .pathSyslogAuditPlugin }}
+    restart_auditd=true
+  fi
+
+  if ! systemctl is-active --quiet auditd.service ; then
+    # Ensure that the auditd service is running.
+    systemctl start auditd.service
+  elif [ "${restart_auditd}" = true ]; then
+    systemctl restart auditd.service
+  fi
+
+  # If the `systemd-journald-audit.socket` socket exists and is enabled, then journald also fetches audit logs from it.
+  # To avoid duplication we disable it and only rely on the syslog audit plugin.
+  if systemctl list-unit-files systemd-journald-audit.socket > /dev/null ; then
+    if systemctl is-enabled --quiet systemd-journald-audit.socket ; then
+      systemctl disable systemd-journald-audit.socket
+    fi
+    if systemctl is-active --quiet systemd-journald-audit.socket ; then
+      systemctl stop systemd-journald-audit.socket
+      systemctl restart systemd-journald
+    fi
   fi
 }
 

--- a/pkg/webhook/operatingsystemconfig/testdata/configure-rsyslog.sh
+++ b/pkg/webhook/operatingsystemconfig/testdata/configure-rsyslog.sh
@@ -28,7 +28,7 @@ function configure_auditd() {
   if [[ -f /etc/audit/plugins.d/syslog.conf ]] && \
       grep -m 1 -qie  "^active\\>" "/etc/audit/plugins.d/syslog.conf" && \
       ! grep -m 1 -qie "^active\\> = yes" "/etc/audit/plugins.d/syslog.conf" ; then
-    sed -i "s/^active\\>.*/active = yes/gi" /etc/audit/plugins.d/syslog.conf
+    sed -i "s/^active\\>.*/active = yes/i" /etc/audit/plugins.d/syslog.conf
     export restart_auditd=true
   fi
 

--- a/pkg/webhook/operatingsystemconfig/testdata/configure-rsyslog.sh
+++ b/pkg/webhook/operatingsystemconfig/testdata/configure-rsyslog.sh
@@ -25,9 +25,11 @@ function configure_auditd() {
     restart_auditd=true
   fi
 
-  if [[ -f /etc/audit/plugins.d/syslog.conf ]] && grep -Fxq "active = no" "/etc/audit/plugins.d/syslog.conf" ; then
-    sed -i 's/no/yes/g' /etc/audit/plugins.d/syslog.conf
-    restart_auditd=true
+  if [[ -f /etc/audit/plugins.d/syslog.conf ]] && \
+      grep -m 1 -qie  "^active\\>" "/etc/audit/plugins.d/syslog.conf" && \
+      ! grep -m 1 -qie "^active\\> = yes" "/etc/audit/plugins.d/syslog.conf" ; then
+    sed -i "s/^active\\>.*/active = yes/gi" /etc/audit/plugins.d/syslog.conf
+    export restart_auditd=true
   fi
 
   if ! systemctl is-active --quiet auditd.service ; then

--- a/pkg/webhook/operatingsystemconfig/testdata/configure-rsyslog.sh
+++ b/pkg/webhook/operatingsystemconfig/testdata/configure-rsyslog.sh
@@ -29,7 +29,7 @@ function configure_auditd() {
       grep -m 1 -qie  "^active\\>" "/etc/audit/plugins.d/syslog.conf" && \
       ! grep -m 1 -qie "^active\\> = yes" "/etc/audit/plugins.d/syslog.conf" ; then
     sed -i "s/^active\\>.*/active = yes/i" /etc/audit/plugins.d/syslog.conf
-    export restart_auditd=true
+    restart_auditd=true
   fi
 
   if ! systemctl is-active --quiet auditd.service ; then

--- a/test/integration/controller/lifecycle/lifecycle_test.go
+++ b/test/integration/controller/lifecycle/lifecycle_test.go
@@ -68,7 +68,7 @@ spec:
           fi
 
           if [[ -f /host/etc/audit/plugins.d/syslog.conf ]]; then
-            sed -i "s/^active\\>.*/active = no/gi" /host/etc/audit/plugins.d/syslog.conf
+            sed -i "s/^active\\>.*/active = no/i" /host/etc/audit/plugins.d/syslog.conf
           fi
 
           chroot /host /bin/bash -c 'if systemctl list-unit-files systemd-journald-audit.socket > /dev/null; then \

--- a/test/integration/controller/lifecycle/lifecycle_test.go
+++ b/test/integration/controller/lifecycle/lifecycle_test.go
@@ -68,7 +68,7 @@ spec:
           fi
 
           if [[ -f /host/etc/audit/plugins.d/syslog.conf ]]; then
-            sed -i 's/yes/no/g' /host/etc/audit/plugins.d/syslog.conf
+            sed -i "s/^active\\>.*/active = no/gi" /host/etc/audit/plugins.d/syslog.conf
           fi
 
           chroot /host /bin/bash -c 'if systemctl list-unit-files systemd-journald-audit.socket > /dev/null; then \

--- a/test/integration/controller/lifecycle/lifecycle_test.go
+++ b/test/integration/controller/lifecycle/lifecycle_test.go
@@ -71,6 +71,12 @@ spec:
             sed -i 's/yes/no/g' /host/etc/audit/plugins.d/syslog.conf
           fi
 
+          chroot /host /bin/bash -c 'if systemctl list-unit-files systemd-journald-audit.socket > /dev/null; then \
+            systemctl enable systemd-journald-audit.socket; \
+            systemctl start systemd-journald-audit.socket; \
+            systemctl restart systemd-journald; \
+          fi'
+
           if [[ -d /host/etc/audit/rules.d.original ]]; then
             if [[ -d /host/etc/audit/rules.d ]]; then
               rm -rf /host/etc/audit/rules.d


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue that caused audit logs to be duplicated when the `system-journald-audit` socket is enabled on the OS. 
Generally, the extension enables the `syslog` plugin for `auditd` in order to forward audit logs to journald on all supported OSes. However, on gardenlinux `system-journald-audit` socket is also enabled, meaning that journald also fetches audit logs from there. This caused audit event messages to be duplicated in journald.

The PR makes it so that the `system-journal-audit` socket is disabled and stopped when the extension is used to align how audit logs are gathered across multiple OSes.
If the extension is disabled, the `system-journal-audit` socket is enabled and started again.

**Which issue(s) this PR fixes**:
Part of #2

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixed an issue that caused audit logs to be duplicated in journald if the `system-journald-audit` socket was enabled. Now if the `system-journald-audit` socket exists on the node, it is disabled and stopped when this extension is used.
```
