### PR TITLE
Restart rsyslog when tls certificates change

### DIFF
--- a/pkg/component/rsyslogrelpconfigcleaner/rsyslog_relp_config_cleaner.go
+++ b/pkg/component/rsyslogrelpconfigcleaner/rsyslog_relp_config_cleaner.go
@@ -194,6 +194,10 @@ if [[ -f /host/etc/rsyslog.d/60-audit.conf ]]; then
   chroot /host /bin/bash -c 'if systemctl list-unit-files rsyslog.service > /dev/null; then systemctl restart rsyslog; fi'
 fi
 
+if [[ -d /host/etc/ssl/rsyslog ]]; then
+  rm -rf /host/etc/ssl/rsyslog
+fi
+
 if [[ -d /host/var/lib/rsyslog-relp-configurator ]]; then
   rm -rf /host/var/lib/rsyslog-relp-configurator
 fi`,

--- a/pkg/webhook/operatingsystemconfig/resources/templates/60-audit.conf.tpl
+++ b/pkg/webhook/operatingsystemconfig/resources/templates/60-audit.conf.tpl
@@ -43,6 +43,8 @@ module(
   bracketing="on"
 )
 
+input(type="imuxsock" Socket="/run/systemd/journal/syslog")
+
 ruleset(name="process_stats") {
   action(
     type="omprog"
@@ -91,5 +93,3 @@ if {{ . }} then {
   stop
 }
 {{- end}}
-
-input(type="imuxsock" Socket="/run/systemd/journal/syslog")

--- a/pkg/webhook/operatingsystemconfig/rsyslog.go
+++ b/pkg/webhook/operatingsystemconfig/rsyslog.go
@@ -26,18 +26,20 @@ import (
 )
 
 const (
-	rsyslogCaPath                  = "/var/lib/rsyslog-relp-configurator/tls/ca.crt"
-	rsyslogCertPath                = "/var/lib/rsyslog-relp-configurator/tls/tls.crt"
-	rsyslogKeyPath                 = "/var/lib/rsyslog-relp-configurator/tls/tls.key"
-	rsyslogConfigFromOSCPath       = "/var/lib/rsyslog-relp-configurator/rsyslog.d/60-audit.conf"
+	rsyslogOSCDir = "/var/lib/rsyslog-relp-configurator"
+
+	rsyslogTLSDir        = "/etc/ssl/rsyslog"
+	rsyslogTLSFromOSCDir = rsyslogOSCDir + "/tls"
+
 	rsyslogConfigPath              = "/etc/rsyslog.d/60-audit.conf"
-	configureRsyslogScriptPath     = "/var/lib/rsyslog-relp-configurator/configure-rsyslog.sh"
-	processRsyslogPstatsScriptPath = "/var/lib/rsyslog-relp-configurator/process-rsyslog-pstats.sh"
+	rsyslogConfigFromOSCPath       = rsyslogOSCDir + "/rsyslog.d/60-audit.conf"
+	configureRsyslogScriptPath     = rsyslogOSCDir + "/configure-rsyslog.sh"
+	processRsyslogPstatsScriptPath = rsyslogOSCDir + "/process-rsyslog-pstats.sh"
 
 	auditRulesDir         = "/etc/audit/rules.d"
 	auditRulesBackupDir   = "/etc/audit/rules.d.original"
-	auditRulesFromOSCDir  = "/var/lib/rsyslog-relp-configurator/audit/rules.d"
 	auditSyslogPluginPath = "/etc/audit/plugins.d/syslog.conf"
+	auditRulesFromOSCDir  = rsyslogOSCDir + "/audit/rules.d"
 
 	nodeExporterTextfileCollectorDir = "/var/lib/node-exporter/textfile-collector"
 )
@@ -75,6 +77,8 @@ func init() {
 	}
 
 	if err := configureRsyslogScriptTemplate.Execute(&configureRsyslogScript, map[string]interface{}{
+		"pathRsyslogTLSDir":           rsyslogTLSDir,
+		"pathRsyslogTLSFromOSCDir":    rsyslogTLSFromOSCDir,
 		"pathAuditRulesDir":           auditRulesDir,
 		"pathAuditRulesBackupDir":     auditRulesBackupDir,
 		"pathAuditRulesFromOSCDir":    auditRulesFromOSCDir,
@@ -200,9 +204,9 @@ func getRsyslogTLSValues(rsyslogRelpConfig *rsyslog.RsyslogRelpConfig) map[strin
 	}
 
 	return map[string]interface{}{
-		"caPath":        rsyslogCaPath,
-		"certPath":      rsyslogCertPath,
-		"keyPath":       rsyslogKeyPath,
+		"caPath":        rsyslogTLSDir + "/ca.crt",
+		"certPath":      rsyslogTLSDir + "/tls.crt",
+		"keyPath":       rsyslogTLSDir + "/tls.key",
 		"enabled":       rsyslogRelpConfig.TLS.Enabled,
 		"permittedPeer": strings.Join(permittedPeers, ","),
 		"authMode":      authMode,
@@ -219,7 +223,7 @@ func getRsyslogTLSFiles(cluster *extensionscontroller.Cluster, secretRefName str
 	refSecretName := v1beta1constants.ReferencedResourcesPrefix + ref.ResourceRef.Name
 	return []extensionsv1alpha1.File{
 		{
-			Path:        rsyslogCaPath,
+			Path:        rsyslogTLSFromOSCDir + "/ca.crt",
 			Permissions: ptr.To(int32(0600)),
 			Content: extensionsv1alpha1.FileContent{
 				SecretRef: &extensionsv1alpha1.FileContentSecretRef{
@@ -229,7 +233,7 @@ func getRsyslogTLSFiles(cluster *extensionscontroller.Cluster, secretRefName str
 			},
 		},
 		{
-			Path:        rsyslogCertPath,
+			Path:        rsyslogTLSFromOSCDir + "/tls.crt",
 			Permissions: ptr.To(int32(0600)),
 			Content: extensionsv1alpha1.FileContent{
 				SecretRef: &extensionsv1alpha1.FileContentSecretRef{
@@ -239,7 +243,7 @@ func getRsyslogTLSFiles(cluster *extensionscontroller.Cluster, secretRefName str
 			},
 		},
 		{
-			Path:        rsyslogKeyPath,
+			Path:        rsyslogTLSFromOSCDir + "/tls.key",
 			Permissions: ptr.To(int32(0600)),
 			Content: extensionsv1alpha1.FileContent{
 				SecretRef: &extensionsv1alpha1.FileContentSecretRef{

--- a/pkg/webhook/operatingsystemconfig/testdata/60-audit-with-tls.conf
+++ b/pkg/webhook/operatingsystemconfig/testdata/60-audit-with-tls.conf
@@ -41,6 +41,8 @@ module(
   bracketing="on"
 )
 
+input(type="imuxsock" Socket="/run/systemd/journal/syslog")
+
 ruleset(name="process_stats") {
   action(
     type="omprog"
@@ -57,9 +59,9 @@ ruleset(name="relp_action_ruleset") {
     port="10250"
     Template="SyslogForwarderTemplate"
     tls="on"
-    tls.caCert="/var/lib/rsyslog-relp-configurator/tls/ca.crt"
-    tls.myCert="/var/lib/rsyslog-relp-configurator/tls/tls.crt"
-    tls.myPrivKey="/var/lib/rsyslog-relp-configurator/tls/tls.key"
+    tls.caCert="/etc/ssl/rsyslog/ca.crt"
+    tls.myCert="/etc/ssl/rsyslog/tls.crt"
+    tls.myPrivKey="/etc/ssl/rsyslog/tls.key"
     tls.authmode="name"
     tls.permittedpeer=["rsyslog-server.foo","rsyslog-server.foo.bar"]
   )
@@ -77,5 +79,3 @@ if $syslogseverity <= 2 then {
   call relp_action_ruleset
   stop
 }
-
-input(type="imuxsock" Socket="/run/systemd/journal/syslog")

--- a/pkg/webhook/operatingsystemconfig/testdata/60-audit.conf
+++ b/pkg/webhook/operatingsystemconfig/testdata/60-audit.conf
@@ -40,6 +40,8 @@ module(
   bracketing="on"
 )
 
+input(type="imuxsock" Socket="/run/systemd/journal/syslog")
+
 ruleset(name="process_stats") {
   action(
     type="omprog"
@@ -70,5 +72,3 @@ if $syslogseverity <= 2 then {
   call relp_action_ruleset
   stop
 }
-
-input(type="imuxsock" Socket="/run/systemd/journal/syslog")

--- a/test/integration/controller/lifecycle/lifecycle_test.go
+++ b/test/integration/controller/lifecycle/lifecycle_test.go
@@ -84,6 +84,10 @@ spec:
             chroot /host /bin/bash -c 'if systemctl list-unit-files rsyslog.service > /dev/null; then systemctl restart rsyslog; fi'
           fi
 
+          if [[ -d /host/etc/ssl/rsyslog ]]; then
+            rm -rf /host/etc/ssl/rsyslog
+          fi
+
           if [[ -d /host/var/lib/rsyslog-relp-configurator ]]; then
             rm -rf /host/var/lib/rsyslog-relp-configurator
           fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind bug

**What this PR does / why we need it**:
Previously rsyslog was not restarted when the tls certificates were changed. This seems to cause issues as the new certificates aren't properly loaded by rsyslog when it tries to execute the action to send logs over the relp channel.

WIth this PR the tls certificates are copied from the directory where they are created by the `gardener-node-agent` to `/etc/ssl/rsyslog` and loaded into rsyslog from there. If the certificates downloaded by `gardener-node-agent` are changed, the old ones are removed from `/etc/ssl/rsyslog`, new ones copied over from their original directory and the rsyslog service is restarted

Additionally, a small change for clarity was made by moving the `input(type="imuxsock" Socket="/run/systemd/journal/syslog")` input a bit up in the rsyslog configuration file.

**Which issue(s) this PR fixes**:
Part of #2

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
If the certificates used for the `rsyslog-relp` tls connection are changed, the `rsyslog` service on the nodes is restarted so that it can properly load the new certificates.
```
