### PR TITLE
Increase permissions of `/etc/ssl/rsyslog` dir

### DIFF
--- a/pkg/webhook/operatingsystemconfig/resources/templates/scripts/configure-rsyslog.tpl.sh
+++ b/pkg/webhook/operatingsystemconfig/resources/templates/scripts/configure-rsyslog.tpl.sh
@@ -42,7 +42,7 @@ function configure_rsyslog() {
 
   if [[ -d {{ .pathRsyslogTLSFromOSCDir }} ]] && [[ -n "$(ls -A "{{ .pathRsyslogTLSFromOSCDir }}" )" ]]; then
     if [[ ! -d {{ .pathRsyslogTLSDir }} ]]; then
-      mkdir -m 0600 {{ .pathRsyslogTLSDir }}
+      mkdir -p {{ .pathRsyslogTLSDir }}
     fi
     if ! diff -rq {{ .pathRsyslogTLSFromOSCDir }} {{ .pathRsyslogTLSDir }} ; then
       rm -rf {{ .pathRsyslogTLSDir }}/*

--- a/pkg/webhook/operatingsystemconfig/testdata/configure-rsyslog.sh
+++ b/pkg/webhook/operatingsystemconfig/testdata/configure-rsyslog.sh
@@ -42,7 +42,7 @@ function configure_rsyslog() {
 
   if [[ -d /var/lib/rsyslog-relp-configurator/tls ]] && [[ -n "$(ls -A "/var/lib/rsyslog-relp-configurator/tls" )" ]]; then
     if [[ ! -d /etc/ssl/rsyslog ]]; then
-      mkdir -m 0600 /etc/ssl/rsyslog
+      mkdir -p /etc/ssl/rsyslog
     fi
     if ! diff -rq /var/lib/rsyslog-relp-configurator/tls /etc/ssl/rsyslog ; then
       rm -rf /etc/ssl/rsyslog/*


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
It seems that when rsyslog is started without `cap_dac_override` as is the case on some OSes, it cannot read from the `/etc/ssl/rsyslog` directory when tls is enabled even if the directory has 0600 permissions. With this PR we will create the directory with default (0755) permissions to avoid this problem. Certificates inside it still have `0600` permissions which does not cause any problems.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The directory where the tls certificates are copied on the node - `/etc/ssl/rsyslog`, is now created with default (`0755`) permissions so that it can be read by an `rsyslog` process that is started without `cap_dac_override` capability. 
```
