### PR TITLE
Enable rsyslog to process logs on suse-chost 15 SP3 nodes

### DIFF
--- a/pkg/component/rsyslogrelpconfigcleaner/rsyslog_relp_config_cleaner.go
+++ b/pkg/component/rsyslogrelpconfigcleaner/rsyslog_relp_config_cleaner.go
@@ -184,6 +184,9 @@ fi
 if [[ -f /host/etc/audit/plugins.d/syslog.conf ]]; then
   sed -i "s/^active\\>.*/active = no/i" /host/etc/audit/plugins.d/syslog.conf
 fi
+if [[ -f /host/etc/audisp/plugins.d/syslog.conf ]]; then
+  sed -i "s/^active\\>.*/active = no/i" /host/etc/audit/plugins.d/syslog.conf
+fi
 
 chroot /host /bin/bash -c 'if systemctl list-unit-files systemd-journald-audit.socket > /dev/null; then \
   systemctl enable systemd-journald-audit.socket; \

--- a/pkg/component/rsyslogrelpconfigcleaner/rsyslog_relp_config_cleaner.go
+++ b/pkg/component/rsyslogrelpconfigcleaner/rsyslog_relp_config_cleaner.go
@@ -185,7 +185,7 @@ if [[ -f /host/etc/audit/plugins.d/syslog.conf ]]; then
   sed -i "s/^active\\>.*/active = no/i" /host/etc/audit/plugins.d/syslog.conf
 fi
 if [[ -f /host/etc/audisp/plugins.d/syslog.conf ]]; then
-  sed -i "s/^active\\>.*/active = no/i" /host/etc/audit/plugins.d/syslog.conf
+  sed -i "s/^active\\>.*/active = no/i" /host/etc/audisp/plugins.d/syslog.conf
 fi
 
 chroot /host /bin/bash -c 'if systemctl list-unit-files systemd-journald-audit.socket > /dev/null; then \

--- a/pkg/webhook/operatingsystemconfig/resources/templates/scripts/configure-rsyslog.tpl.sh
+++ b/pkg/webhook/operatingsystemconfig/resources/templates/scripts/configure-rsyslog.tpl.sh
@@ -26,8 +26,8 @@ function configure_auditd() {
   fi
 
   path_syslog_audit_plugin={{ .pathSyslogAuditPlugin }}
-  if [[ -f {{ .pathSyslogAuditPluginAlternative }} ]]; then
-    path_syslog_audit_plugin={{ .pathSyslogAuditPluginAlternative }}
+  if [[ -f {{ .audispSyslogPluginPath }} ]]; then
+    path_syslog_audit_plugin={{ .audispSyslogPluginPath }}
   fi
   if [[ -f "$path_syslog_audit_plugin" ]] && \
       grep -m 1 -qie  "^active\\>" "$path_syslog_audit_plugin" && \

--- a/pkg/webhook/operatingsystemconfig/resources/templates/scripts/configure-rsyslog.tpl.sh
+++ b/pkg/webhook/operatingsystemconfig/resources/templates/scripts/configure-rsyslog.tpl.sh
@@ -25,10 +25,14 @@ function configure_auditd() {
     restart_auditd=true
   fi
 
-  if [[ -f {{ .pathSyslogAuditPlugin }} ]] && \
-      grep -m 1 -qie  "^active\\>" "{{ .pathSyslogAuditPlugin }}" && \
-      ! grep -m 1 -qie "^active\\> = yes" "{{ .pathSyslogAuditPlugin }}" ; then
-    sed -i "s/^active\\>.*/active = yes/i" {{ .pathSyslogAuditPlugin }}
+  path_syslog_audit_plugin={{ .pathSyslogAuditPlugin }}
+  if [[ -f {{ .pathSyslogAuditPluginAlternative }} ]]; then
+    path_syslog_audit_plugin={{ .pathSyslogAuditPluginAlternative }}
+  fi
+  if [[ -f "$path_syslog_audit_plugin" ]] && \
+      grep -m 1 -qie  "^active\\>" "$path_syslog_audit_plugin" && \
+      ! grep -m 1 -qie "^active\\> = yes" "$path_syslog_audit_plugin" ; then
+    sed -i "s/^active\\>.*/active = yes/i" "$path_syslog_audit_plugin"
     restart_auditd=true
   fi
 

--- a/pkg/webhook/operatingsystemconfig/rsyslog.go
+++ b/pkg/webhook/operatingsystemconfig/rsyslog.go
@@ -38,11 +38,11 @@ const (
 
 	rsyslogRelpQueueSpoolDir = "/var/log/rsyslog"
 
-	auditRulesDir                    = "/etc/audit/rules.d"
-	auditRulesBackupDir              = "/etc/audit/rules.d.original"
-	auditSyslogPluginPath            = "/etc/audit/plugins.d/syslog.conf"
+	auditRulesDir          = "/etc/audit/rules.d"
+	auditRulesBackupDir    = "/etc/audit/rules.d.original"
+	auditSyslogPluginPath  = "/etc/audit/plugins.d/syslog.conf"
 	audispSyslogPluginPath = "/etc/audisp/plugins.d/syslog.conf"
-	auditRulesFromOSCDir             = rsyslogOSCDir + "/audit/rules.d"
+	auditRulesFromOSCDir   = rsyslogOSCDir + "/audit/rules.d"
 
 	nodeExporterTextfileCollectorDir = "/var/lib/node-exporter/textfile-collector"
 )
@@ -80,16 +80,16 @@ func init() {
 	}
 
 	if err := configureRsyslogScriptTemplate.Execute(&configureRsyslogScript, map[string]interface{}{
-		"rsyslogRelpQueueSpoolDir":         rsyslogRelpQueueSpoolDir,
-		"pathRsyslogTLSDir":                rsyslogTLSDir,
-		"pathRsyslogTLSFromOSCDir":         rsyslogTLSFromOSCDir,
-		"pathAuditRulesDir":                auditRulesDir,
-		"pathAuditRulesBackupDir":          auditRulesBackupDir,
-		"pathAuditRulesFromOSCDir":         auditRulesFromOSCDir,
-		"pathSyslogAuditPlugin":            auditSyslogPluginPath,
-		"pathSyslogAuditPluginAlternative": auditSyslogPluginPathAlternative,
-		"pathRsyslogAuditConf":             rsyslogConfigPath,
-		"pathRsyslogAuditConfFromOSC":      rsyslogConfigFromOSCPath,
+		"rsyslogRelpQueueSpoolDir":    rsyslogRelpQueueSpoolDir,
+		"pathRsyslogTLSDir":           rsyslogTLSDir,
+		"pathRsyslogTLSFromOSCDir":    rsyslogTLSFromOSCDir,
+		"pathAuditRulesDir":           auditRulesDir,
+		"pathAuditRulesBackupDir":     auditRulesBackupDir,
+		"pathAuditRulesFromOSCDir":    auditRulesFromOSCDir,
+		"pathSyslogAuditPlugin":       auditSyslogPluginPath,
+		"audispSyslogPluginPath":      audispSyslogPluginPath,
+		"pathRsyslogAuditConf":        rsyslogConfigPath,
+		"pathRsyslogAuditConfFromOSC": rsyslogConfigFromOSCPath,
 	}); err != nil {
 		panic(err)
 	}

--- a/pkg/webhook/operatingsystemconfig/rsyslog.go
+++ b/pkg/webhook/operatingsystemconfig/rsyslog.go
@@ -38,10 +38,11 @@ const (
 
 	rsyslogRelpQueueSpoolDir = "/var/log/rsyslog"
 
-	auditRulesDir         = "/etc/audit/rules.d"
-	auditRulesBackupDir   = "/etc/audit/rules.d.original"
-	auditSyslogPluginPath = "/etc/audit/plugins.d/syslog.conf"
-	auditRulesFromOSCDir  = rsyslogOSCDir + "/audit/rules.d"
+	auditRulesDir                    = "/etc/audit/rules.d"
+	auditRulesBackupDir              = "/etc/audit/rules.d.original"
+	auditSyslogPluginPath            = "/etc/audit/plugins.d/syslog.conf"
+	auditSyslogPluginPathAlternative = "/etc/audisp/plugins.d/syslog.conf"
+	auditRulesFromOSCDir             = rsyslogOSCDir + "/audit/rules.d"
 
 	nodeExporterTextfileCollectorDir = "/var/lib/node-exporter/textfile-collector"
 )
@@ -79,15 +80,16 @@ func init() {
 	}
 
 	if err := configureRsyslogScriptTemplate.Execute(&configureRsyslogScript, map[string]interface{}{
-		"rsyslogRelpQueueSpoolDir":    rsyslogRelpQueueSpoolDir,
-		"pathRsyslogTLSDir":           rsyslogTLSDir,
-		"pathRsyslogTLSFromOSCDir":    rsyslogTLSFromOSCDir,
-		"pathAuditRulesDir":           auditRulesDir,
-		"pathAuditRulesBackupDir":     auditRulesBackupDir,
-		"pathAuditRulesFromOSCDir":    auditRulesFromOSCDir,
-		"pathSyslogAuditPlugin":       auditSyslogPluginPath,
-		"pathRsyslogAuditConf":        rsyslogConfigPath,
-		"pathRsyslogAuditConfFromOSC": rsyslogConfigFromOSCPath,
+		"rsyslogRelpQueueSpoolDir":         rsyslogRelpQueueSpoolDir,
+		"pathRsyslogTLSDir":                rsyslogTLSDir,
+		"pathRsyslogTLSFromOSCDir":         rsyslogTLSFromOSCDir,
+		"pathAuditRulesDir":                auditRulesDir,
+		"pathAuditRulesBackupDir":          auditRulesBackupDir,
+		"pathAuditRulesFromOSCDir":         auditRulesFromOSCDir,
+		"pathSyslogAuditPlugin":            auditSyslogPluginPath,
+		"pathSyslogAuditPluginAlternative": auditSyslogPluginPathAlternative,
+		"pathRsyslogAuditConf":             rsyslogConfigPath,
+		"pathRsyslogAuditConfFromOSC":      rsyslogConfigFromOSCPath,
 	}); err != nil {
 		panic(err)
 	}

--- a/pkg/webhook/operatingsystemconfig/rsyslog.go
+++ b/pkg/webhook/operatingsystemconfig/rsyslog.go
@@ -41,7 +41,7 @@ const (
 	auditRulesDir                    = "/etc/audit/rules.d"
 	auditRulesBackupDir              = "/etc/audit/rules.d.original"
 	auditSyslogPluginPath            = "/etc/audit/plugins.d/syslog.conf"
-	auditSyslogPluginPathAlternative = "/etc/audisp/plugins.d/syslog.conf"
+	audispSyslogPluginPath = "/etc/audisp/plugins.d/syslog.conf"
 	auditRulesFromOSCDir             = rsyslogOSCDir + "/audit/rules.d"
 
 	nodeExporterTextfileCollectorDir = "/var/lib/node-exporter/textfile-collector"

--- a/pkg/webhook/operatingsystemconfig/testdata/configure-rsyslog.sh
+++ b/pkg/webhook/operatingsystemconfig/testdata/configure-rsyslog.sh
@@ -25,10 +25,14 @@ function configure_auditd() {
     restart_auditd=true
   fi
 
-  if [[ -f /etc/audit/plugins.d/syslog.conf ]] && \
-      grep -m 1 -qie  "^active\\>" "/etc/audit/plugins.d/syslog.conf" && \
-      ! grep -m 1 -qie "^active\\> = yes" "/etc/audit/plugins.d/syslog.conf" ; then
-    sed -i "s/^active\\>.*/active = yes/i" /etc/audit/plugins.d/syslog.conf
+  path_syslog_audit_plugin=/etc/audit/plugins.d/syslog.conf
+  if [[ -f /etc/audisp/plugins.d/syslog.conf ]]; then
+    path_syslog_audit_plugin=/etc/audisp/plugins.d/syslog.conf
+  fi
+  if [[ -f "$path_syslog_audit_plugin" ]] && \
+      grep -m 1 -qie  "^active\\>" "$path_syslog_audit_plugin" && \
+      ! grep -m 1 -qie "^active\\> = yes" "$path_syslog_audit_plugin" ; then
+    sed -i "s/^active\\>.*/active = yes/i" "$path_syslog_audit_plugin"
     restart_auditd=true
   fi
 

--- a/test/integration/controller/lifecycle/lifecycle_test.go
+++ b/test/integration/controller/lifecycle/lifecycle_test.go
@@ -75,7 +75,7 @@ spec:
             sed -i "s/^active\\>.*/active = no/i" /host/etc/audit/plugins.d/syslog.conf
           fi
           if [[ -f /host/etc/audisp/plugins.d/syslog.conf ]]; then
-            sed -i "s/^active\\>.*/active = no/i" /host/etc/audit/plugins.d/syslog.conf
+            sed -i "s/^active\\>.*/active = no/i" /host/etc/audisp/plugins.d/syslog.conf
           fi
 
           chroot /host /bin/bash -c 'if systemctl list-unit-files systemd-journald-audit.socket > /dev/null; then \

--- a/test/integration/controller/lifecycle/lifecycle_test.go
+++ b/test/integration/controller/lifecycle/lifecycle_test.go
@@ -74,6 +74,9 @@ spec:
           if [[ -f /host/etc/audit/plugins.d/syslog.conf ]]; then
             sed -i "s/^active\\>.*/active = no/i" /host/etc/audit/plugins.d/syslog.conf
           fi
+          if [[ -f /host/etc/audisp/plugins.d/syslog.conf ]]; then
+            sed -i "s/^active\\>.*/active = no/i" /host/etc/audit/plugins.d/syslog.conf
+          fi
 
           chroot /host /bin/bash -c 'if systemctl list-unit-files systemd-journald-audit.socket > /dev/null; then \
             systemctl enable systemd-journald-audit.socket; \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug where on suse-chost 15 SP3 nodes no auditd logs are being processed by rsyslog

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/issues/4

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Rsyslog processes logs on nodes with os suse-chost 15 SP3 
```
