### PR TITLE
Improve testmachinery tests and add checks for forwarding of audit logs

### DIFF
--- a/.test-defs/TestSuiteShootRsyslogRelpBetaSerial.yaml
+++ b/.test-defs/TestSuiteShootRsyslogRelpBetaSerial.yaml
@@ -6,7 +6,7 @@ spec:
   owner: gardener-oq@listserv.sap.com
   description: shoot-rsyslog-relp extension test suite that includes all serial beta tests
 
-  activeDeadlineSeconds: 10200
+  activeDeadlineSeconds: 12300
   labels: ["shoot", "beta"]
   behavior:
   - serial

--- a/.test-defs/TestSuiteShootRsyslogRelpBetaSerial.yaml
+++ b/.test-defs/TestSuiteShootRsyslogRelpBetaSerial.yaml
@@ -21,5 +21,6 @@ spec:
       -shoot-name=$SHOOT_NAME
       -ginkgo.focus="\[BETA\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
+      -ginkgo.timeout=2h
 
   image: golang:1.22.5

--- a/.test-defs/TestSuiteShootRsyslogRelpBetaSerial.yaml
+++ b/.test-defs/TestSuiteShootRsyslogRelpBetaSerial.yaml
@@ -6,7 +6,7 @@ spec:
   owner: gardener-oq@listserv.sap.com
   description: shoot-rsyslog-relp extension test suite that includes all serial beta tests
 
-  activeDeadlineSeconds: 12300
+  activeDeadlineSeconds: 13200
   labels: ["shoot", "beta"]
   behavior:
   - serial
@@ -21,6 +21,6 @@ spec:
       -shoot-name=$SHOOT_NAME
       -ginkgo.focus="\[BETA\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
-      -ginkgo.timeout=2h
+      -ginkgo.timeout=13200s
 
   image: golang:1.22.5

--- a/test/common/configuration.go
+++ b/test/common/configuration.go
@@ -122,6 +122,13 @@ func WithTarget(target string) func(rsyslogRelpConfig *rsyslogv1alpha1.RsyslogRe
 	}
 }
 
+// AppendLoggingRule appends the given loggingRule to the logging rules of the rsyslog relp configuration.
+func AppendLoggingRule(loggingRule rsyslogv1alpha1.LoggingRule) func(rsyslogRelpConfig *rsyslogv1alpha1.RsyslogRelpConfig) {
+	return func(rsyslogRelpConfig *rsyslogv1alpha1.RsyslogRelpConfig) {
+		rsyslogRelpConfig.LoggingRules = append(rsyslogRelpConfig.LoggingRules, loggingRule)
+	}
+}
+
 // WithTLSWithSecretRefNameAndTLSLib returns a function which enables TLS for the rsyslog relp configuration and sets
 // the tls.secretRefName to the given secretRefName and tls.tlsLib to the given tlsLib.
 func WithTLSWithSecretRefNameAndTLSLib(secretRefName, tlsLib string) func(rsyslogRelpConfig *rsyslogv1alpha1.RsyslogRelpConfig) {

--- a/test/e2e/create_enable_disable_delete.go
+++ b/test/e2e/create_enable_disable_delete.go
@@ -53,7 +53,7 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 
 			echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootFramework.SeedClient)
 			Expect(err).NotTo(HaveOccurred())
-			verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, echoServerPodIf, echoServerPodName, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID))
+			verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, echoServerPodIf, echoServerPodName, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID), false)
 
 			common.ForEachNode(ctx, f.ShootFramework.ShootClient, func(ctx context.Context, node *corev1.Node) {
 				verifier.VerifyExtensionForNode(ctx, node.Name)

--- a/test/e2e/create_enable_force_delete.go
+++ b/test/e2e/create_enable_force_delete.go
@@ -46,7 +46,7 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 
 		echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootFramework.SeedClient)
 		Expect(err).NotTo(HaveOccurred())
-		verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, echoServerPodIf, echoServerPodName, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID))
+		verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, echoServerPodIf, echoServerPodName, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID), false)
 
 		common.ForEachNode(ctx, f.ShootFramework.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)

--- a/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
+++ b/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 
 		echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootFramework.SeedClient)
 		Expect(err).NotTo(HaveOccurred())
-		verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, echoServerPodIf, echoServerPodName, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID))
+		verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, echoServerPodIf, echoServerPodName, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID), false)
 
 		common.ForEachNode(ctx, f.ShootFramework.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)

--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	defaultTestTimeout        = 30 * time.Minute
+	defaultTestTimeout        = 50 * time.Minute
 	defaultTestCleanupTimeout = 10 * time.Minute
 )
 
@@ -39,7 +39,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 		Expect(f.UpdateShoot(ctx, shootMutateFn)).To(Succeed())
 
 		By("Verify shoot-rsyslog-relp works")
-		ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)
+		ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
 		defer cancel()
 		echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootClient)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 		Expect(deleteRsyslogRelpEchoServer(ctx, f))
 	}, time.Minute)
 
-	Context("shoot-rsyslog-relp extension with tls disabled", Label("tls-disabled"), func() {
+	FContext("shoot-rsyslog-relp extension with tls disabled", Label("tls-disabled"), func() {
 		f.Serial().Beta().CIt("should enable and disable the shoot-rsyslog-relp extension", func(parentCtx context.Context) {
 			test(parentCtx, func(shoot *gardencorev1beta1.Shoot) error {
 				common.AddOrUpdateRsyslogRelpExtension(shoot, common.WithTarget(echoServerIP))

--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 		Expect(deleteRsyslogRelpEchoServer(ctx, f))
 	}, time.Minute)
 
-	FContext("shoot-rsyslog-relp extension with tls disabled", Label("tls-disabled"), func() {
+	Context("shoot-rsyslog-relp extension with tls disabled", Label("tls-disabled"), func() {
 		f.Serial().Beta().CIt("should enable and disable the shoot-rsyslog-relp extension", func(parentCtx context.Context) {
 			test(parentCtx, func(shoot *gardencorev1beta1.Shoot) error {
 				common.AddOrUpdateRsyslogRelpExtension(

--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -17,6 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	rsyslogv1alpha1 "github.com/gardener/gardener-extension-shoot-rsyslog-relp/pkg/apis/rsyslog/v1alpha1"
 	"github.com/gardener/gardener-extension-shoot-rsyslog-relp/test/common"
 )
 
@@ -42,7 +43,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 		defer cancel()
 		echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootClient)
 		Expect(err).NotTo(HaveOccurred())
-		verifier := common.NewVerifier(f.Logger, f.ShootClient, echoServerPodIf, echoServerPodName, f.Shoot.Spec.Provider.Type, f.Project.Name, f.Shoot.Name, string(f.Shoot.UID))
+		verifier := common.NewVerifier(f.Logger, f.ShootClient, echoServerPodIf, echoServerPodName, f.Shoot.Spec.Provider.Type, f.Project.Name, f.Shoot.Name, string(f.Shoot.UID), true)
 
 		common.ForEachNode(ctx, f.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)
@@ -79,7 +80,11 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 	FContext("shoot-rsyslog-relp extension with tls disabled", Label("tls-disabled"), func() {
 		f.Serial().Beta().CIt("should enable and disable the shoot-rsyslog-relp extension", func(parentCtx context.Context) {
 			test(parentCtx, func(shoot *gardencorev1beta1.Shoot) error {
-				common.AddOrUpdateRsyslogRelpExtension(shoot, common.WithTarget(echoServerIP))
+				common.AddOrUpdateRsyslogRelpExtension(
+					shoot,
+					common.WithTarget(echoServerIP),
+					common.AppendLoggingRule(rsyslogv1alpha1.LoggingRule{ProgramNames: []string{"audisp-syslog", "audispd"}, Severity: 7}),
+				)
 				return nil
 			})
 		}, defaultTestTimeout, framework.WithCAfterTest(func(ctx context.Context) {
@@ -108,7 +113,13 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			test(parentCtx, func(shoot *gardencorev1beta1.Shoot) error {
-				common.AddOrUpdateRsyslogRelpExtension(shoot, common.WithPort(443), common.WithTLSWithSecretRefNameAndTLSLib(secretReferenceName, "openssl"), common.WithTarget(echoServerIP))
+				common.AddOrUpdateRsyslogRelpExtension(
+					shoot,
+					common.WithPort(443),
+					common.WithTLSWithSecretRefNameAndTLSLib(secretReferenceName, "openssl"),
+					common.WithTarget(echoServerIP),
+					common.AppendLoggingRule(rsyslogv1alpha1.LoggingRule{ProgramNames: []string{"audisp-syslog", "audispd"}, Severity: 7}),
+				)
 				common.AddOrUpdateRsyslogTLSSecretResource(shoot, secretReferenceName)
 				return nil
 			})

--- a/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
+++ b/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 
 		echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootClient)
 		Expect(err).NotTo(HaveOccurred())
-		verifier := common.NewVerifier(f.Logger, f.ShootClient, echoServerPodIf, echoServerPodName, f.Shoot.Spec.Provider.Type, f.Project.Name, f.Shoot.Name, string(f.Shoot.UID))
+		verifier := common.NewVerifier(f.Logger, f.ShootClient, echoServerPodIf, echoServerPodName, f.Shoot.Spec.Provider.Type, f.Project.Name, f.Shoot.Name, string(f.Shoot.UID), false)
 
 		common.ForEachNode(ctx, f.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)

--- a/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
+++ b/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	hibernationTestTimeout        = 60 * time.Minute
+	hibernationTestTimeout        = 75 * time.Minute
 	hibernationTestCleanupTimeout = 25 * time.Minute
 )
 
@@ -43,7 +43,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 		})).To(Succeed())
 
 		By("Verify shoot-rsyslog-relp works")
-		ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)
+		ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
 		defer cancel()
 
 		echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootClient)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR tries to improve mainly the testmachinery tests by reducing the `exec` calls that were previously performed - instead of using a separate `exec` to generating each log line, now one `exec` will be used to generate all logs.

Additionally, forwarding of audit logs is now also checked. If instructed to, the test will create a file under the `/etc` directory. As per the audit rules this should generate an audit event of the file creation. The audit event contains the name of the file and the operation that created it. During the verification we look for the name of the file in the log lines retrieved from the echo server.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:



**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
