### PR TITLE
Ignore errors when loading audit rules

### DIFF
--- a/pkg/webhook/operatingsystemconfig/resources/auditrules/00-base-config.rules
+++ b/pkg/webhook/operatingsystemconfig/resources/auditrules/00-base-config.rules
@@ -14,3 +14,5 @@
 --backlog_wait_time 60000
 ## Set failure mode to syslog
 -f 1
+## Ignore errors when loading rules
+-i

--- a/pkg/webhook/operatingsystemconfig/resources/auditrules/11-privileged-special.rules
+++ b/pkg/webhook/operatingsystemconfig/resources/auditrules/11-privileged-special.rules
@@ -6,4 +6,8 @@
 ## The original file was moved to /etc/audit/rules.d.original
 
 -a exit,always -F arch=b64 -S mount -S umount2 -S mknod -S mknodat -S chroot -F auid!=-1 -F key=privileged_special
+
+## The mount_setattr kernel function is available only linux kernel versions >= 5.12.
+## It is specified in a separate rule so that the rule for the system
+## calls above can be safely loaded on kernel versions < 5.12.
 -a exit,always -F arch=b64 -S mount_setattr -F auid!=-1 -F key=privileged_special

--- a/pkg/webhook/operatingsystemconfig/resources/auditrules/11-privileged-special.rules
+++ b/pkg/webhook/operatingsystemconfig/resources/auditrules/11-privileged-special.rules
@@ -5,4 +5,5 @@
 ## This file is managed by the shoot-rsyslog-relp extension
 ## The original file was moved to /etc/audit/rules.d.original
 
--a exit,always -F arch=b64 -S mount -S mount_setattr -S umount2 -S mknod -S mknodat -S chroot -F auid!=-1 -F key=privileged_special
+-a exit,always -F arch=b64 -S mount -S umount2 -S mknod -S mknodat -S chroot -F auid!=-1 -F key=privileged_special
+-a exit,always -F arch=b64 -S mount_setattr -F auid!=-1 -F key=privileged_special

--- a/pkg/webhook/operatingsystemconfig/testdata/00-base-config.rules
+++ b/pkg/webhook/operatingsystemconfig/testdata/00-base-config.rules
@@ -14,3 +14,5 @@
 --backlog_wait_time 60000
 ## Set failure mode to syslog
 -f 1
+## Ignore errors when loading rules
+-i

--- a/pkg/webhook/operatingsystemconfig/testdata/11-privileged-special.rules
+++ b/pkg/webhook/operatingsystemconfig/testdata/11-privileged-special.rules
@@ -6,4 +6,8 @@
 ## The original file was moved to /etc/audit/rules.d.original
 
 -a exit,always -F arch=b64 -S mount -S umount2 -S mknod -S mknodat -S chroot -F auid!=-1 -F key=privileged_special
+
+## The mount_setattr kernel function is available only linux kernel versions >= 5.12.
+## It is specified in a separate rule so that the rule for the system
+## calls above can be safely loaded on kernel versions < 5.12.
 -a exit,always -F arch=b64 -S mount_setattr -F auid!=-1 -F key=privileged_special

--- a/pkg/webhook/operatingsystemconfig/testdata/11-privileged-special.rules
+++ b/pkg/webhook/operatingsystemconfig/testdata/11-privileged-special.rules
@@ -5,4 +5,5 @@
 ## This file is managed by the shoot-rsyslog-relp extension
 ## The original file was moved to /etc/audit/rules.d.original
 
--a exit,always -F arch=b64 -S mount -S mount_setattr -S umount2 -S mknod -S mknodat -S chroot -F auid!=-1 -F key=privileged_special
+-a exit,always -F arch=b64 -S mount -S umount2 -S mknod -S mknodat -S chroot -F auid!=-1 -F key=privileged_special
+-a exit,always -F arch=b64 -S mount_setattr -F auid!=-1 -F key=privileged_special


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
Audit rules are loaded sequentially and once an error is encountered, no further rules are loaded. This PR makes it so that errors are ignored when loading the predefined linux audit rules which are part of this extension. Errors generally come from kernel versions that do not support a particular system call part of the rules. This allows all rules to be loaded with the exception of the erroneous ones.
This change concretely targets the case where the `mount_setattr` system call is not available in linux kernel versions <= `5.12` (it is the only system call which causes this problem from the predefined rules). This is why it is now also extracted in a separate rule.

**Which issue(s) this PR fixes**:
Part of #2

**Special notes for your reviewer**:
As part of the task which exposes audit rules so that they can be configured by users, I will add monitoring/alerts for errors/warnings that occur when loading them. 
Whether or not to set the `-i` option (so that errors are ignored and reported as warnings) will also be left to the users to decide.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Errors that can occur when loading audit rules are now ignored and reported as warnings. This allows all correct audit rules to be loaded.
```
