### PR TITLE
[admission] Add `priorityClassName`

### DIFF
--- a/charts/gardener-extension-shoot-rsyslog-relp-admission/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-extension-shoot-rsyslog-relp-admission/charts/runtime/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         {{- end }}
 {{ include "labels" . | indent 8 }}
     spec:
+      {{- if .Values.global.priorityClassName }}
+      priorityClassName: {{ .Values.global.priorityClassName }}
+      {{- end }}
       serviceAccountName: {{ include "name" . }}
       {{- if .Values.global.kubeconfig }}
       automountServiceAccountToken: false

--- a/charts/gardener-extension-shoot-rsyslog-relp-admission/values.yaml
+++ b/charts/gardener-extension-shoot-rsyslog-relp-admission/values.yaml
@@ -12,6 +12,7 @@ global:
     repository: europe-docker.pkg.dev/gardener-project/public/gardener/extensions/shoot-rsyslog-relp-admission
     tag: latest
     pullPolicy: IfNotPresent
+# priorityClassName: gardener-garden-system-400
   replicaCount: 1
   resources:
     requests:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the admission chart by the option to set a `priorityClassName`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9936.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A `priorityClassName` can now be set for the admission deployment via the `gardener-extension-shoot-rsyslog-relp-admission` Helm chart.
```