### PR TITLE
Fix remote extension setup

### DIFF
--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- controller-registration.yaml

--- a/local-setup/kustomization.yaml
+++ b/local-setup/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-
 resources:
 - ../example
 

--- a/local-setup/kustomization.yaml
+++ b/local-setup/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+
+resources:
+- ../example
+
+patches:
+- patch: |
+    - op: replace
+      path: /providerConfig/values/image
+      value: local-skaffold/gardener/extensions/shoot-rsyslog-relp
+  target:
+    group: core.gardener.cloud
+    kind: ControllerDeployment
+    name: extension-shoot-rsyslog-relp

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,10 +4,10 @@ metadata:
   name: rsyslog-relp-echo-server
 build:
   artifacts:
-    - image: europe-docker.pkg.dev/gardener-project/public/gardener/extensions/shoot-rsyslog-relp-echo-server
+    - image: local-skaffold/gardener/extensions/shoot-rsyslog-relp-echo-server
       docker:
         cacheFrom:
-          - europe-docker.pkg.dev/gardener-project/public/gardener/extensions/shoot-rsyslog-relp-echo-server
+          - local-skaffold/gardener/extensions/shoot-rsyslog-relp-echo-server
   local: {}
 deploy:
   helm:
@@ -18,7 +18,7 @@ deploy:
         wait: true
         chartPath: example/local/charts/rsyslog-relp-echo-server
         setValueTemplates:
-          images.rsyslog: '{{.IMAGE_FULLY_QUALIFIED_europe_docker_pkg_dev_gardener_project_public_gardener_extensions_shoot_rsyslog_relp_echo_server}}'
+          images.rsyslog: '{{.IMAGE_FULLY_QUALIFIED_local_skaffold_gardener_extensions_shoot_rsyslog_relp_echo_server}}'
         setValues:
           service.clusterIP: 10.2.64.54
 ---
@@ -28,7 +28,7 @@ metadata:
   name: extension
 build:
   artifacts:
-    - image: europe-docker.pkg.dev/gardener-project/public/gardener/extensions/shoot-rsyslog-relp
+    - image: local-skaffold/gardener/extensions/shoot-rsyslog-relp
       ko:
         dependencies:
           paths:
@@ -57,8 +57,9 @@ resourceSelector:
     - groupKind: ControllerDeployment.core.gardener.cloud
       image: [".*"]
 manifests:
-  rawYaml:
-    - example/controller-registration.yaml
+  kustomize:
+    paths:
+    - local-setup
 deploy:
   kubectl: {}
 ---
@@ -68,7 +69,7 @@ metadata:
   name: admission
 build:
   artifacts:
-    - image: europe-docker.pkg.dev/gardener-project/public/gardener/extensions/shoot-rsyslog-relp-admission
+    - image: local-skaffold/gardener/extensions/shoot-rsyslog-relp-admission
       ko:
         dependencies:
           paths:
@@ -94,8 +95,8 @@ deploy:
         wait: true
         chartPath: charts/gardener-extension-shoot-rsyslog-relp-admission
         setValueTemplates:
-          global.image.repository: '{{.IMAGE_REPO_europe_docker_pkg_dev_gardener_project_public_gardener_extensions_shoot_rsyslog_relp_admission}}'
-          global.image.tag: '{{.IMAGE_TAG_europe_docker_pkg_dev_gardener_project_public_gardener_extensions_shoot_rsyslog_relp_admission}}@{{.IMAGE_DIGEST_europe_docker_pkg_dev_gardener_project_public_gardener_extensions_shoot_rsyslog_relp_admission}}'
+          global.image.repository: '{{.IMAGE_REPO_local_skaffold_gardener_extensions_shoot_rsyslog_relp_admission}}'
+          global.image.tag: '{{.IMAGE_TAG_local_skaffold_gardener_extensions_shoot_rsyslog_relp_admission}}@{{.IMAGE_DIGEST_local_skaffold_gardener_extensions_shoot_rsyslog_relp_admission}}'
 profiles:
   - name: remote-extension
     patches:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind regression

**What this PR does / why we need it**:
This PR fixes the remote extension setup.

With https://github.com/gardener/gardener/pull/9782 the name with which gardener images are built with skaffold was changed and consequently the kyverno policies were changed to reflect that: https://github.com/gardener/gardener/pull/9782/files#diff-98574cc407c84776352d2e2fdea6d82ad1e194fa7a5961c14cdfe2eb2bea1271
This caused the `shoot-rsyslog-relp` extension remote setup to stop working as its image names were not changed and it depends on the same kyverno policies. This PR adapts the name of the images to be the same as the ones used in gardener. The changes here are similar to the ones in https://github.com/gardener/gardener-extension-registry-cache/pull/193


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
