### PR TITLE
Limit the memory of the rsyslog service

### DIFF
--- a/pkg/webhook/operatingsystemconfig/ensurer_test.go
+++ b/pkg/webhook/operatingsystemconfig/ensurer_test.go
@@ -346,6 +346,19 @@ func getRsyslogFiles(rsyslogConfig []byte, useExpectedContent bool) []extensions
 				},
 			},
 		},
+		{
+			Path:        "/etc/systemd/system/rsyslog.service.d/10-shoot-rsyslog-relp-memory-limits.conf",
+			Permissions: ptr.To(int32(0644)),
+			Content: extensionsv1alpha1.FileContent{
+				Inline: &extensionsv1alpha1.FileContentInline{
+					Data: getBasedOnCondition(useExpectedContent, `[Service]
+MemoryMin=15M
+MemoryHigh=150M
+MemoryMax=300M
+MemorySwapMax=0`, "old"),
+				},
+			},
+		},
 	}
 }
 

--- a/pkg/webhook/operatingsystemconfig/rsyslog.go
+++ b/pkg/webhook/operatingsystemconfig/rsyslog.go
@@ -31,6 +31,8 @@ const (
 	rsyslogTLSDir        = "/etc/ssl/rsyslog"
 	rsyslogTLSFromOSCDir = rsyslogOSCDir + "/tls"
 
+	rsyslogServiceMemoryLimitsDropInPath = "/etc/systemd/system/rsyslog.service.d/10-shoot-rsyslog-relp-memory-limits.conf"
+
 	rsyslogConfigPath              = "/etc/rsyslog.d/60-audit.conf"
 	rsyslogConfigFromOSCPath       = rsyslogOSCDir + "/rsyslog.d/60-audit.conf"
 	configureRsyslogScriptPath     = rsyslogOSCDir + "/configure-rsyslog.sh"
@@ -156,6 +158,19 @@ func getRsyslogFiles(rsyslogRelpConfig *rsyslog.RsyslogRelpConfig, cluster *exte
 				Inline: &extensionsv1alpha1.FileContentInline{
 					Encoding: "b64",
 					Data:     gardenerutils.EncodeBase64(processRsyslogPstatsScript.Bytes()),
+				},
+			},
+		},
+		{
+			Path:        rsyslogServiceMemoryLimitsDropInPath,
+			Permissions: ptr.To(int32(0644)),
+			Content: extensionsv1alpha1.FileContent{
+				Inline: &extensionsv1alpha1.FileContentInline{
+					Data: `[Service]
+MemoryMin=15M
+MemoryHigh=150M
+MemoryMax=300M
+MemorySwapMax=0`,
 				},
 			},
 		},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind enhancement

**What this PR does / why we need it**:
This PR adds memory configurations for the `rsyslog.service` by adding a drop-in with the following content:

```
MemoryMin=15M
MemoryHigh=150M
MemoryMax=300M
MemorySwapMax=0
```

`MemoryMin` specifies the usual working memory of rsyslog, which is 15M - this memory should not be reclaimed by other services once rsyslog is restarted.
`MemoryHigh` specifies the memory after which the service will be throttled. 150M is the memory at which the rsyslog-relp action queue and the disk queue are full and the main queue of the rsyslog service is starting to get filled.
`MemoryMax` specifies the maximum amount of memory that the service can have after which it will be OOMKilled. The queues are usually full at around 200M-250M of memory, however this additional buffer is added in case of larger messages in the queues (queues get filled based on the number of messages, not their size).

The main reason for adding this PR, even though the queues that rsyslog uses are limited, is because there could still be memory leaks that could potentially lead to nodes getting all their memory consumed: https://github.com/rsyslog/rsyslog/issues/5318

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The memory of the `rsyslog.service` systemd unit is now limited via a drop-in config. The following configurations are used: `MemoryMin=15M`, `MemoryHigh=150M`, `MemoryMax=300M`, `MemorySwapMax=0`
```
