### PR TITLE
Move cleanup code to `clean-rsyslog.tpl.sh` 

### DIFF
--- a/pkg/component/rsyslogrelpconfigcleaner/resources/templates/scripts/clean-rsyslog.tpl.sh
+++ b/pkg/component/rsyslogrelpconfigcleaner/resources/templates/scripts/clean-rsyslog.tpl.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if [[ -f /host/etc/systemd/system/rsyslog-configurator.service ]]; then
+  chroot /host /bin/bash -c 'systemctl disable rsyslog-configurator; systemctl stop rsyslog-configurator; rm -f /etc/systemd/system/rsyslog-configurator.service'
+fi
+
+if [[ -d {{ .rsyslogRelpQueueSpoolDir}} ]]; then
+  rm -rf {{ .rsyslogRelpQueueSpoolDir}}
+fi
+
+if [[ -f {{ .pathSyslogAuditPlugin}} ]]; then
+  sed -i "s/^active\\>.*/active = no/i" {{ .pathSyslogAuditPlugin}}
+fi
+if [[ -f {{ .audispSyslogPluginPath}} ]]; then
+  sed -i "s/^active\\>.*/active = no/i" {{ .audispSyslogPluginPath}}
+fi
+
+chroot /host /bin/bash -c 'if systemctl list-unit-files systemd-journald-audit.socket > /dev/null; then \
+  systemctl enable systemd-journald-audit.socket; \
+  systemctl start systemd-journald-audit.socket; \
+  systemctl restart systemd-journald; \
+fi'
+
+if [[ -d {{ .pathAuditRulesBackupDir}} ]]; then
+  if [[ -d {{ .pathAuditRulesDir}} ]]; then
+    rm -rf {{ .pathAuditRulesDir}}
+  fi
+  mv {{ .pathAuditRulesBackupDir}} {{ .pathAuditRulesDir}}
+  chroot /host /bin/bash -c 'if systemctl list-unit-files auditd.service > /dev/null; then augenrules --load; systemctl restart auditd; fi'
+fi
+
+if [[ -f {{ .pathRsyslogAuditConf}} ]]; then
+  rm -f {{ .pathRsyslogAuditConf}}
+  chroot /host /bin/bash -c 'if systemctl list-unit-files rsyslog.service > /dev/null; then systemctl restart rsyslog; fi'
+fi
+
+if [[ -d {{ .pathRsyslogTLSDir}} ]]; then
+  rm -rf {{ .pathRsyslogTLSDir}}
+fi
+
+if [[ -d {{ .pathRsyslogOSCDir }} ]]; then
+  rm -rf {{ .pathRsyslogOSCDir }}
+fi

--- a/pkg/component/rsyslogrelpconfigcleaner/rsyslog_relp_config_cleaner.go
+++ b/pkg/component/rsyslogrelpconfigcleaner/rsyslog_relp_config_cleaner.go
@@ -5,9 +5,13 @@
 package rsyslogrelpconfigcleaner
 
 import (
+	"bytes"
 	"context"
+	_ "embed"
+	"text/template"
 	"time"
 
+	"github.com/Masterminds/sprig"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
@@ -169,50 +173,64 @@ func getLabels() map[string]string {
 	}
 }
 
+var (
+	//go:embed resources/templates/scripts/clean-rsyslog.tpl.sh
+	cleanRsyslogScriptTemplateContent string
+	cleanRsyslogScript                bytes.Buffer
+)
+
+const (
+	rsyslogOSCDir = "/var/lib/rsyslog-relp-configurator"
+
+	rsyslogTLSDir        = "/etc/ssl/rsyslog"
+	rsyslogTLSFromOSCDir = rsyslogOSCDir + "/tls"
+
+	rsyslogConfigPath              = "/etc/rsyslog.d/60-audit.conf"
+	rsyslogConfigFromOSCPath       = rsyslogOSCDir + "/rsyslog.d/60-audit.conf"
+	configureRsyslogScriptPath     = rsyslogOSCDir + "/configure-rsyslog.sh"
+	processRsyslogPstatsScriptPath = rsyslogOSCDir + "/process-rsyslog-pstats.sh"
+
+	rsyslogRelpQueueSpoolDir = "/var/log/rsyslog"
+
+	auditRulesDir          = "/etc/audit/rules.d"
+	auditRulesBackupDir    = "/etc/audit/rules.d.original"
+	auditSyslogPluginPath  = "/etc/audit/plugins.d/syslog.conf"
+	audispSyslogPluginPath = "/etc/audisp/plugins.d/syslog.conf"
+	auditRulesFromOSCDir   = rsyslogOSCDir + "/audit/rules.d"
+)
+
+func init() {
+	var err error
+
+	cleanRsyslogScriptTemplate, err := template.
+		New("clean-rsyslog.sh").
+		Funcs(sprig.TxtFuncMap()).
+		Parse(cleanRsyslogScriptTemplateContent)
+	if err != nil {
+		panic(err)
+	}
+
+	if err := cleanRsyslogScriptTemplate.Execute(&cleanRsyslogScript, map[string]interface{}{
+		"rsyslogRelpQueueSpoolDir":    "/host" + rsyslogRelpQueueSpoolDir,
+		"pathRsyslogTLSDir":           "/host" + rsyslogTLSDir,
+		"pathRsyslogTLSFromOSCDir":    "/host" + rsyslogTLSFromOSCDir,
+		"pathAuditRulesDir":           "/host" + auditRulesDir,
+		"pathAuditRulesBackupDir":     "/host" + auditRulesBackupDir,
+		"pathAuditRulesFromOSCDir":    "/host" + auditRulesFromOSCDir,
+		"pathSyslogAuditPlugin":       "/host" + auditSyslogPluginPath,
+		"audispSyslogPluginPath":      "/host" + audispSyslogPluginPath,
+		"pathRsyslogAuditConf":        "/host" + rsyslogConfigPath,
+		"pathRsyslogAuditConfFromOSC": "/host" + rsyslogConfigFromOSCPath,
+		"pathRsyslogOSCDir":           "/host" + rsyslogOSCDir,
+	}); err != nil {
+		panic(err)
+	}
+}
+
 func computeCommand() []string {
 	return []string{
 		"sh",
 		"-c",
-		`if [[ -f /host/etc/systemd/system/rsyslog-configurator.service ]]; then
-  chroot /host /bin/bash -c 'systemctl disable rsyslog-configurator; systemctl stop rsyslog-configurator; rm -f /etc/systemd/system/rsyslog-configurator.service'
-fi
-
-if [[ -d /host/var/log/rsyslog ]]; then
-  rm -rf /host/var/log/rsyslog
-fi
-
-if [[ -f /host/etc/audit/plugins.d/syslog.conf ]]; then
-  sed -i "s/^active\\>.*/active = no/i" /host/etc/audit/plugins.d/syslog.conf
-fi
-if [[ -f /host/etc/audisp/plugins.d/syslog.conf ]]; then
-  sed -i "s/^active\\>.*/active = no/i" /host/etc/audisp/plugins.d/syslog.conf
-fi
-
-chroot /host /bin/bash -c 'if systemctl list-unit-files systemd-journald-audit.socket > /dev/null; then \
-  systemctl enable systemd-journald-audit.socket; \
-  systemctl start systemd-journald-audit.socket; \
-  systemctl restart systemd-journald; \
-fi'
-
-if [[ -d /host/etc/audit/rules.d.original ]]; then
-  if [[ -d /host/etc/audit/rules.d ]]; then
-    rm -rf /host/etc/audit/rules.d
-  fi
-  mv /host/etc/audit/rules.d.original /host/etc/audit/rules.d
-  chroot /host /bin/bash -c 'if systemctl list-unit-files auditd.service > /dev/null; then augenrules --load; systemctl restart auditd; fi'
-fi
-
-if [[ -f /host/etc/rsyslog.d/60-audit.conf ]]; then
-  rm -f /host/etc/rsyslog.d/60-audit.conf
-  chroot /host /bin/bash -c 'if systemctl list-unit-files rsyslog.service > /dev/null; then systemctl restart rsyslog; fi'
-fi
-
-if [[ -d /host/etc/ssl/rsyslog ]]; then
-  rm -rf /host/etc/ssl/rsyslog
-fi
-
-if [[ -d /host/var/lib/rsyslog-relp-configurator ]]; then
-  rm -rf /host/var/lib/rsyslog-relp-configurator
-fi`,
+		cleanRsyslogScript.String(),
 	}
 }

--- a/test/integration/controller/lifecycle/lifecycle_test.go
+++ b/test/integration/controller/lifecycle/lifecycle_test.go
@@ -71,7 +71,13 @@ var _ = Describe("Lifecycle controller tests", func() {
 								Command: []string{
 									"sh",
 									"-c",
-									`if [[ -f /host/etc/systemd/system/rsyslog-configurator.service ]]; then
+									`#!/bin/bash
+
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if [[ -f /host/etc/systemd/system/rsyslog-configurator.service ]]; then
   chroot /host /bin/bash -c 'systemctl disable rsyslog-configurator; systemctl stop rsyslog-configurator; rm -f /etc/systemd/system/rsyslog-configurator.service'
 fi
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
This PR moves the cleanup bash script from inline string in `pkg/component/rsyslogrelpconfigcleaner/rsyslog_relp_config_cleaner.go` to `pkg/component/rsyslogrelpconfigcleaner/resources/templates/scripts/clean-rsyslog.tpl.sh`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
