### PR TITLE
Fix flake at `The function passed to Consistently failed at /src/test/common/verifier.go:147`

### DIFF
--- a/test/common/verifier.go
+++ b/test/common/verifier.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/gardener/gardener/test/framework"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -159,26 +158,20 @@ func (v *Verifier) verifyThatLogsAreNotForwardedToEchoServer(ctx context.Context
 		return v.generateLogs(ctx, logEntries)
 	}).WithTimeout(30*time.Second).WithPolling(10*time.Second).WithContext(ctx).Should(Succeed(), fmt.Sprintf("Expected to successfully generate logs for node %s", v.nodeName))
 
-	By("waiting 30 seconds before checking for logs")
+	By("Wait 30 seconds before checking for logs")
 	timer := time.NewTimer(30 * time.Second)
 	select {
 	case <-ctx.Done():
-		Fail("context deadline exceeded")
+		Fail("context deadline exceeded while waiting to check for logs")
 	case <-timer.C:
 	}
 
-	By("validating there are no logs")
-	Expect(retry.UntilTimeout(ctx, 10*time.Second, 30*time.Second, func(ctx context.Context) (done bool, err error) {
+	By("Verify that there are no logs")
+	EventuallyWithOffset(2, func(g Gomega) {
 		logLines, err := v.getLogs(ctx, timeBeforeLogGeneration)
-		if err != nil {
-			return retry.MinorError(fmt.Errorf("error while getting logs : %w", err))
-		}
-		if len(logLines) > 0 {
-			return retry.SevereError(fmt.Errorf("expected not to receive any logs, got %s", strings.Join(logLines, ", ")))
-		}
-		return retry.Ok()
-	})).NotTo(HaveOccurred())
-
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(logLines).To(BeEmpty())
+	}).WithTimeout(30*time.Second).WithPolling(10*time.Second).WithContext(ctx).Should(Succeed(), fmt.Sprintf("Expected to successfully generate logs for node %s and logs to NOT be present in rsyslog-relp-echo-server", v.nodeName))
 }
 
 func (v *Verifier) setPodExecutor(rootPodExecutor framework.RootPodExecutor) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug where a `Consistenly` block was flaking

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/issues/152

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
