### PR TITLE
Testmachinery test uses rsyslog-tls secret with unique name

### DIFF
--- a/example/shoot.yaml
+++ b/example/shoot.yaml
@@ -59,6 +59,7 @@ spec:
   region: local
   networking:
     type: calico
+    nodes: 10.10.0.0/16
     providerConfig:
       apiVersion: calico.networking.extensions.gardener.cloud/v1alpha1
       kind: NetworkConfig

--- a/test/common/testdata/audit/audit-configmap.yaml
+++ b/test/common/testdata/audit/audit-configmap.yaml
@@ -1,7 +1,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: audit-config-v1
+  generateName: audit-config-v1-
   namespace: garden-local
 immutable: true
 data:

--- a/test/common/testdata/tls/rsyslog-relp-secret.yaml
+++ b/test/common/testdata/tls/rsyslog-relp-secret.yaml
@@ -1,7 +1,7 @@
 kind: Secret
 apiVersion: v1
 metadata:
-  name: rsyslog-relp-tls-v1
+  generateName: rsyslog-relp-tls-
   namespace: garden-local
 immutable: true
 stringData:

--- a/test/common/utils.go
+++ b/test/common/utils.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
+	testutils "github.com/gardener/gardener/pkg/utils/test"
 	"github.com/gardener/gardener/test/framework"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
@@ -57,4 +58,18 @@ func ExecCommand(ctx context.Context, log logr.Logger, podExecutor framework.Roo
 		return retry.Ok()
 	})
 	return
+}
+
+// CreateResourcesFromFile creates the objects from filePath with a given namespace name
+func CreateResourcesFromFile(ctx context.Context, client client.Client, namespaceName string, filePath string) ([]client.Object, error) {
+	resources, err := testutils.ReadTestResources(client.Scheme(), namespaceName, filePath)
+	if err != nil {
+		return nil, err
+	}
+	for _, obj := range resources {
+		if err = client.Create(ctx, obj); err != nil {
+			return nil, err
+		}
+	}
+	return resources, nil
 }

--- a/test/e2e/create_enable_disable_delete.go
+++ b/test/e2e/create_enable_disable_delete.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	testutils "github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
 	"github.com/gardener/gardener/test/framework"
@@ -109,7 +108,7 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 
 			By("Create rsyslog-relp tls Secret")
 			var err error
-			createdResources, err = testutils.EnsureTestResources(ctx, f.GardenClient.Client(), f.ProjectNamespace, "../common/testdata/tls")
+			createdResources, err = common.CreateResourcesFromFile(ctx, f.GardenClient.Client(), f.ProjectNamespace, "../common/testdata/tls")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(createdResources)).ToNot(BeZero())
 		})

--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	testutils "github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	"github.com/gardener/gardener/test/framework"
 	. "github.com/onsi/ginkgo/v2"
@@ -145,12 +144,9 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 			defer cancel()
 
 			var err error
-			createdResources, err = testutils.ReadTestResources(f.GardenClient.Client().Scheme(), f.ProjectNamespace, "../../common/testdata/tls")
+			createdResources, err = common.CreateResourcesFromFile(ctx, f.GardenClient.Client(), f.ProjectNamespace, "../../common/testdata/tls")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(createdResources)).ToNot(BeZero())
-			for _, obj := range createdResources {
-				Expect(f.GardenClient.Client().Create(ctx, obj)).NotTo(HaveOccurred())
-			}
 
 			test(parentCtx, defaultExtensionAuditRules, func(shoot *gardencorev1beta1.Shoot) error {
 				common.AddOrUpdateRsyslogRelpExtension(
@@ -190,7 +186,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 			defer cancel()
 
 			var err error
-			createdResources, err = testutils.EnsureTestResources(ctx, f.GardenClient.Client(), f.ProjectNamespace, "../../common/testdata/audit")
+			createdResources, err = common.CreateResourcesFromFile(ctx, f.GardenClient.Client(), f.ProjectNamespace, "../../common/testdata/audit")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(createdResources)).ToNot(BeZero())
 

--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -145,9 +145,12 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 			defer cancel()
 
 			var err error
-			createdResources, err = testutils.EnsureTestResources(ctx, f.GardenClient.Client(), f.ProjectNamespace, "../../common/testdata/tls")
+			createdResources, err = testutils.ReadTestResources(f.GardenClient.Client().Scheme(), f.ProjectNamespace, "../../common/testdata/tls")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(createdResources)).ToNot(BeZero())
+			for _, obj := range createdResources {
+				Expect(f.GardenClient.Client().Create(ctx, obj)).NotTo(HaveOccurred())
+			}
 
 			test(parentCtx, defaultExtensionAuditRules, func(shoot *gardencorev1beta1.Shoot) error {
 				common.AddOrUpdateRsyslogRelpExtension(


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind flake

**What this PR does / why we need it**:
Testmachinery test now generates rsyslog-relp-tls secret to have a unique suffix that will prevent collisions with other tests

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/issues/153

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
