### PR TITLE
Nit: Fix a warning for deprecated config usage in .golangci.yaml

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,9 +2,6 @@ run:
   concurrency: 4
   deadline: 10m
 
-  skip-files:
-  - "zz_generated\\..*\\.go$"
-
 linters:
   disable:
   - unused
@@ -14,13 +11,16 @@ linters:
 issues:
   exclude-use-default: false
   exclude:
-    # revive:
-    - var-naming # ((var|const|struct field|func) .* should be .*
-    - dot-imports # should not use dot imports
-    - package-comments # package comment should be of the form
-    - unexported-return # exported func .* returns unexported type .*, which can be annoying to use
-    - indent-error-flow # if block ends with a return statement, so drop this else and outdent its block
-    - "exported: (type|func) name will be used as .* by other packages, and that stutters;"
-    # typecheck:
-    - "undeclared name: `.*`"
-    - "\".*\" imported but not used"
+  # revive:
+  - var-naming # ((var|const|struct field|func) .* should be .*
+  - dot-imports # should not use dot imports
+  - package-comments # package comment should be of the form
+  - unexported-return # exported func .* returns unexported type .*, which can be annoying to use
+  - indent-error-flow # if block ends with a return statement, so drop this else and outdent its block
+  - "exported: (type|func) name will be used as .* by other packages, and that stutters;"
+  # typecheck:
+  - "undeclared name: `.*`"
+  - "\".*\" imported but not used"
+
+  exclude-files:
+  - "zz_generated\\..*\\.go$"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
Running `make check` outputs the following warning:
```
> Check
Executing golangci-lint
WARN [config_reader] The configuration option `run.skip-files` is deprecated, please use `issues.exclude-files`.
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
