### PR TITLE
Expect upper case `-- MARK --` message during test

### DIFF
--- a/test/common/verifier.go
+++ b/test/common/verifier.go
@@ -170,11 +170,11 @@ func (v *Verifier) verifyThatLogsAreNotForwardedToEchoServer(ctx context.Context
 	EventuallyWithOffset(2, func(g Gomega) {
 		logLines, err := v.getLogs(ctx, timeBeforeLogGeneration)
 		g.Expect(err).NotTo(HaveOccurred())
-		// Rsyslog outputs a "-- Mark --" message as a form of heartbeat each 1200 seconds (by default) to indicate that it is working properly.
+		// Rsyslog outputs a "-- MARK --" message as a form of heartbeat each 1200 seconds (by default) to indicate that it is working properly.
 		// This log comes from the rsyslog server itself and must be ignored when checking if there were no logs sent from the rsyslog clients.
 		// ContainSubstring is used as there could be spaces at the start or end of the log message depending on the template with which the
 		// rsyslog server is configured.
-		g.Expect(logLines).To(Or(BeEmpty(), ConsistOf(ContainSubstring("-- Mark --"))))
+		g.Expect(logLines).To(Or(BeEmpty(), ConsistOf(ContainSubstring("-- MARK --"))))
 	}).WithTimeout(30*time.Second).WithPolling(10*time.Second).WithContext(ctx).Should(Succeed(), fmt.Sprintf("Expected to successfully generate logs for node %s and logs to NOT be present in rsyslog-relp-echo-server", v.nodeName))
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind flake

**What this PR does / why we need it**:
The `-- MARK --` messages that are output by rsyslog as a form of heartbeat are upper case. 
This PR modifies the expected logs apprproately

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
