### PR TITLE
Fix flake at `The function passed to Consistently failed at /src/test/common/verifier.go:146`

### DIFF
--- a/test/common/verifier.go
+++ b/test/common/verifier.go
@@ -141,7 +141,16 @@ func (v *Verifier) verifyLogsAreForwardedToEchoServer(ctx context.Context, logEn
 	}
 
 	if len(notForwardedLogMatchers) > 0 {
-		ConsistentlyWithOffset(2, func(g Gomega) {
+		By("Wait 30 seconds before checking for logs")
+		timer := time.NewTimer(30 * time.Second)
+		select {
+		case <-ctx.Done():
+			Fail("context deadline exceeded while waiting to check for logs")
+		case <-timer.C:
+		}
+
+		By("Verify that there are no logs")
+		EventuallyWithOffset(2, func(g Gomega) {
 			logLines, err := v.getLogs(ctx, timeBeforeLogGeneration)
 			g.Expect(err).NotTo(HaveOccurred())
 			// Iterate over all matchers to ensure that none of them are contained in the log lines.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug where a `Consistenly` block was flaking

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/issues/180

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
