### PR TITLE
Get echo server pod at `getLogs`

### DIFF
--- a/test/common/verifier.go
+++ b/test/common/verifier.go
@@ -27,6 +27,7 @@ const fileForAuditEvent = "/etc/newfile"
 type Verifier struct {
 	log                logr.Logger
 	client             kubernetes.Interface
+	clientForLogs      kubernetes.Interface
 	providerType       string
 	nodeName           string
 	projectName        string
@@ -46,13 +47,14 @@ type logEntry struct {
 
 // NewVerifier creates a new Verifier.
 func NewVerifier(log logr.Logger,
-	client kubernetes.Interface,
+	client, clientForLogs kubernetes.Interface,
 	providerType, projectName, shootName, shootUID string,
 	testAuditLogging bool,
 	expectedAuditRules string) *Verifier {
 	return &Verifier{
 		log:                log,
 		client:             client,
+		clientForLogs:      clientForLogs,
 		providerType:       providerType,
 		projectName:        projectName,
 		shootName:          shootName,
@@ -196,7 +198,7 @@ func (v *Verifier) generateLogs(ctx context.Context, logEntries []logEntry) erro
 }
 
 func (v *Verifier) getLogs(ctx context.Context, timeBeforeLogGeneration metav1.Time) ([]string, error) {
-	echoServerPodIf, echoServerPodName, err := GetEchoServerPodInterfaceAndName(ctx, v.client)
+	echoServerPodIf, echoServerPodName, err := GetEchoServerPodInterfaceAndName(ctx, v.clientForLogs)
 	if err != nil {
 		return nil, err
 	}

--- a/test/common/verifier.go
+++ b/test/common/verifier.go
@@ -19,25 +19,22 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 const fileForAuditEvent = "/etc/newfile"
 
 // Verifier is a struct that can be used to verify whether the shoot-rsyslog-relp extension is working as expected.
 type Verifier struct {
-	log                        logr.Logger
-	client                     kubernetes.Interface
-	rsyslogRelpEchoServerPodIf clientcorev1.PodInterface
-	rsyslogEchoServerPodName   string
-	providerType               string
-	nodeName                   string
-	projectName                string
-	shootName                  string
-	shootUID                   string
-	rootPodExecutor            framework.RootPodExecutor
-	testAuditLogging           bool
-	expectedAuditRules         string
+	log                logr.Logger
+	client             kubernetes.Interface
+	providerType       string
+	nodeName           string
+	projectName        string
+	shootName          string
+	shootUID           string
+	rootPodExecutor    framework.RootPodExecutor
+	testAuditLogging   bool
+	expectedAuditRules string
 }
 
 type logEntry struct {
@@ -50,28 +47,19 @@ type logEntry struct {
 // NewVerifier creates a new Verifier.
 func NewVerifier(log logr.Logger,
 	client kubernetes.Interface,
-	echoServerPodIf clientcorev1.PodInterface,
-	echoServerPodName, providerType, projectName, shootName, shootUID string,
+	providerType, projectName, shootName, shootUID string,
 	testAuditLogging bool,
 	expectedAuditRules string) *Verifier {
 	return &Verifier{
-		log:                        log,
-		client:                     client,
-		rsyslogRelpEchoServerPodIf: echoServerPodIf,
-		rsyslogEchoServerPodName:   echoServerPodName,
-		providerType:               providerType,
-		projectName:                projectName,
-		shootName:                  shootName,
-		shootUID:                   shootUID,
-		testAuditLogging:           testAuditLogging,
-		expectedAuditRules:         expectedAuditRules,
+		log:                log,
+		client:             client,
+		providerType:       providerType,
+		projectName:        projectName,
+		shootName:          shootName,
+		shootUID:           shootUID,
+		testAuditLogging:   testAuditLogging,
+		expectedAuditRules: expectedAuditRules,
 	}
-}
-
-// SetEchoServerPodIfAndName sets the clientcorev1.PodInterface and the name of the rsyslog-relp-echo-server pod to the Verifier.
-func (v *Verifier) SetEchoServerPodIfAndName(echoServerPodIf clientcorev1.PodInterface, echoServerPodName string) {
-	v.rsyslogRelpEchoServerPodIf = echoServerPodIf
-	v.rsyslogEchoServerPodName = echoServerPodName
 }
 
 // VerifyExtensionForNode verifies whether the shoot-rsyslog-relp extension has properly configured
@@ -208,7 +196,11 @@ func (v *Verifier) generateLogs(ctx context.Context, logEntries []logEntry) erro
 }
 
 func (v *Verifier) getLogs(ctx context.Context, timeBeforeLogGeneration metav1.Time) ([]string, error) {
-	logs, err := kubernetes.GetPodLogs(ctx, v.rsyslogRelpEchoServerPodIf, v.rsyslogEchoServerPodName, &corev1.PodLogOptions{SinceTime: &timeBeforeLogGeneration})
+	echoServerPodIf, echoServerPodName, err := GetEchoServerPodInterfaceAndName(ctx, v.client)
+	if err != nil {
+		return nil, err
+	}
+	logs, err := kubernetes.GetPodLogs(ctx, echoServerPodIf, echoServerPodName, &corev1.PodLogOptions{SinceTime: &timeBeforeLogGeneration})
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/create_enable_disable_delete.go
+++ b/test/e2e/create_enable_disable_delete.go
@@ -50,9 +50,7 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 			ctx, cancel = context.WithTimeout(parentCtx, 5*time.Minute)
 			DeferCleanup(cancel)
 
-			echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootFramework.SeedClient)
-			Expect(err).NotTo(HaveOccurred())
-			verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, echoServerPodIf, echoServerPodName, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID), false, "")
+			verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID), false, "")
 
 			common.ForEachNode(ctx, f.ShootFramework.ShootClient, func(ctx context.Context, node *corev1.Node) {
 				verifier.VerifyExtensionForNode(ctx, node.Name)

--- a/test/e2e/create_enable_disable_delete.go
+++ b/test/e2e/create_enable_disable_delete.go
@@ -50,7 +50,7 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 			ctx, cancel = context.WithTimeout(parentCtx, 5*time.Minute)
 			DeferCleanup(cancel)
 
-			verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID), false, "")
+			verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, f.ShootFramework.SeedClient, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID), false, "")
 
 			common.ForEachNode(ctx, f.ShootFramework.ShootClient, func(ctx context.Context, node *corev1.Node) {
 				verifier.VerifyExtensionForNode(ctx, node.Name)

--- a/test/e2e/create_enable_force_delete.go
+++ b/test/e2e/create_enable_force_delete.go
@@ -44,7 +44,7 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 		ctx, cancel = context.WithTimeout(parentCtx, 5*time.Minute)
 		DeferCleanup(cancel)
 
-		verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID), false, "")
+		verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, f.ShootFramework.SeedClient, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID), false, "")
 
 		common.ForEachNode(ctx, f.ShootFramework.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)

--- a/test/e2e/create_enable_force_delete.go
+++ b/test/e2e/create_enable_force_delete.go
@@ -44,9 +44,7 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 		ctx, cancel = context.WithTimeout(parentCtx, 5*time.Minute)
 		DeferCleanup(cancel)
 
-		echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootFramework.SeedClient)
-		Expect(err).NotTo(HaveOccurred())
-		verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, echoServerPodIf, echoServerPodName, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID), false, "")
+		verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID), false, "")
 
 		common.ForEachNode(ctx, f.ShootFramework.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)

--- a/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
+++ b/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
@@ -43,9 +43,7 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 		ctx, cancel = context.WithTimeout(parentCtx, 5*time.Minute)
 		DeferCleanup(cancel)
 
-		echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootFramework.SeedClient)
-		Expect(err).NotTo(HaveOccurred())
-		verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, echoServerPodIf, echoServerPodName, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID), false, "")
+		verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID), false, "")
 
 		common.ForEachNode(ctx, f.ShootFramework.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)

--- a/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
+++ b/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 		ctx, cancel = context.WithTimeout(parentCtx, 5*time.Minute)
 		DeferCleanup(cancel)
 
-		verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID), false, "")
+		verifier := common.NewVerifier(f.Logger, f.ShootFramework.ShootClient, f.ShootFramework.SeedClient, f.Shoot.Spec.Provider.Type, f.ShootFramework.Project.Name, f.Shoot.Name, string(f.Shoot.UID), false, "")
 
 		common.ForEachNode(ctx, f.ShootFramework.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)

--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 		By("Verify shoot-rsyslog-relp works")
 		ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
 		defer cancel()
-		verifier := common.NewVerifier(f.Logger, f.ShootClient, f.Shoot.Spec.Provider.Type, f.Project.Name, f.Shoot.Name, string(f.Shoot.UID), true, expectedAuditRules)
+		verifier := common.NewVerifier(f.Logger, f.ShootClient, f.ShootClient, f.Shoot.Spec.Provider.Type, f.Project.Name, f.Shoot.Name, string(f.Shoot.UID), true, expectedAuditRules)
 
 		common.ForEachNode(ctx, f.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)

--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -76,9 +76,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 		By("Verify shoot-rsyslog-relp works")
 		ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
 		defer cancel()
-		echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootClient)
-		Expect(err).NotTo(HaveOccurred())
-		verifier := common.NewVerifier(f.Logger, f.ShootClient, echoServerPodIf, echoServerPodName, f.Shoot.Spec.Provider.Type, f.Project.Name, f.Shoot.Name, string(f.Shoot.UID), true, expectedAuditRules)
+		verifier := common.NewVerifier(f.Logger, f.ShootClient, f.Shoot.Spec.Provider.Type, f.Project.Name, f.Shoot.Name, string(f.Shoot.UID), true, expectedAuditRules)
 
 		common.ForEachNode(ctx, f.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)

--- a/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
+++ b/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
@@ -46,9 +46,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 		ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
 		defer cancel()
 
-		echoServerPodIf, echoServerPodName, err := common.GetEchoServerPodInterfaceAndName(ctx, f.ShootClient)
-		Expect(err).NotTo(HaveOccurred())
-		verifier := common.NewVerifier(f.Logger, f.ShootClient, echoServerPodIf, echoServerPodName, f.Shoot.Spec.Provider.Type, f.Project.Name, f.Shoot.Name, string(f.Shoot.UID), false, "")
+		verifier := common.NewVerifier(f.Logger, f.ShootClient, f.Shoot.Spec.Provider.Type, f.Project.Name, f.Shoot.Name, string(f.Shoot.UID), false, "")
 
 		common.ForEachNode(ctx, f.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)
@@ -76,9 +74,6 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 		By("Verify shoot-rsyslog-relp works after Shoot is woken up")
 		ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)
 		defer cancel()
-		echoServerPodIf, echoServerPodName, err = common.GetEchoServerPodInterfaceAndName(ctx, f.ShootClient)
-		Expect(err).NotTo(HaveOccurred())
-		verifier.SetEchoServerPodIfAndName(echoServerPodIf, echoServerPodName)
 
 		common.ForEachNode(ctx, f.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)

--- a/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
+++ b/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 		ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
 		defer cancel()
 
-		verifier := common.NewVerifier(f.Logger, f.ShootClient, f.Shoot.Spec.Provider.Type, f.Project.Name, f.Shoot.Name, string(f.Shoot.UID), false, "")
+		verifier := common.NewVerifier(f.Logger, f.ShootClient, f.ShootClient, f.Shoot.Spec.Provider.Type, f.Project.Name, f.Shoot.Name, string(f.Shoot.UID), false, "")
 
 		common.ForEachNode(ctx, f.ShootClient, func(ctx context.Context, node *corev1.Node) {
 			verifier.VerifyExtensionForNode(ctx, node.Name)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
This PR gets the echo server pod at the beginning of `getLogs`

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/issues/179

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
