### PR TITLE
Fix local setup issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,7 @@ ci-e2e-kind: $(KIND) $(YQ)
 export SKAFFOLD_BUILD_CONCURRENCY = 0
 extension-up extension-dev: export SKAFFOLD_DEFAULT_REPO = garden.local.gardener.cloud:5001
 extension-up extension-dev: export SKAFFOLD_PUSH = true
+extension-up extension-dev: export EXTENSION_VERSION = $(VERSION)
 # use static label for skaffold to prevent rolling all gardener components on every `skaffold` invocation
 extension-up extension-dev extension-down: export SKAFFOLD_LABEL = skaffold.dev/run-id=extension-local
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,15 +5,6 @@ metadata:
 build:
   insecureRegistries:
     - garden.local.gardener.cloud:5001
-  tagPolicy:
-    customTemplate:
-      template: "{{.version}}-{{.sha}}"
-      components:
-        - name: version
-          envTemplate:
-            template: "{{.EXTENSION_VERSION}}"
-        - name: sha
-          inputDigest: {}
   artifacts:
     - image: local-skaffold/gardener-extension-shoot-rsyslog-relp-echo-server
       docker:
@@ -47,6 +38,8 @@ build:
         - name: version
           envTemplate:
             template: "{{.EXTENSION_VERSION}}"
+        # inputDigest is used to inject a digest of the artifact source into the built image tag
+        # and therefore into the SKAFFOLD_IMAGE environment variable which is used when generating the corresponding ControllerDeployment
         - name: sha
           inputDigest: {}
   artifacts:
@@ -109,15 +102,6 @@ metadata:
 build:
   insecureRegistries:
     - garden.local.gardener.cloud:5001
-  tagPolicy:
-    customTemplate:
-      template: "{{.version}}-{{.sha}}"
-      components:
-        - name: version
-          envTemplate:
-            template: "{{.EXTENSION_VERSION}}"
-        - name: sha
-          inputDigest: {}
   artifacts:
     - image: local-skaffold/gardener-extension-shoot-rsyslog-relp-admission
       ko:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta3
+apiVersion: skaffold/v4beta7
 kind: Config
 metadata:
   name: rsyslog-relp-echo-server
@@ -24,7 +24,7 @@ deploy:
         setValues:
           service.clusterIP: 10.2.64.54
 ---
-apiVersion: skaffold/v4beta3
+apiVersion: skaffold/v4beta7
 kind: Config
 metadata:
   name: extension
@@ -84,7 +84,7 @@ deploy:
         - --server-side
         - --force-conflicts
 ---
-apiVersion: skaffold/v4beta3
+apiVersion: skaffold/v4beta7
 kind: Config
 metadata:
   name: admission

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -73,7 +73,16 @@ manifests:
     paths:
     - local-setup
 deploy:
-  kubectl: {}
+  # --server-side apply is a workaround for https://github.com/gardener/gardener/issues/10267.
+  # kubectl apply attempts a strategic merge patch which fails for a ControllerDeployment.
+  # For more details, see https://github.com/gardener/gardener/issues/10267.
+  #
+  # TODO: Switch back to "kubectl: {}" when the above issue is resolved.
+  kubectl:
+    flags:
+      apply:
+        - --server-side
+        - --force-conflicts
 ---
 apiVersion: skaffold/v4beta3
 kind: Config

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,6 +5,15 @@ metadata:
 build:
   insecureRegistries:
     - garden.local.gardener.cloud:5001
+  tagPolicy:
+    customTemplate:
+      template: "{{.version}}-{{.sha}}"
+      components:
+        - name: version
+          envTemplate:
+            template: "{{.EXTENSION_VERSION}}"
+        - name: sha
+          inputDigest: {}
   artifacts:
     - image: local-skaffold/gardener-extension-shoot-rsyslog-relp-echo-server
       docker:
@@ -31,6 +40,15 @@ metadata:
 build:
   insecureRegistries:
     - garden.local.gardener.cloud:5001
+  tagPolicy:
+    customTemplate:
+      template: "{{.version}}-{{.sha}}"
+      components:
+        - name: version
+          envTemplate:
+            template: "{{.EXTENSION_VERSION}}"
+        - name: sha
+          inputDigest: {}
   artifacts:
     - image: local-skaffold/gardener-extension-shoot-rsyslog-relp
       ko:
@@ -91,6 +109,15 @@ metadata:
 build:
   insecureRegistries:
     - garden.local.gardener.cloud:5001
+  tagPolicy:
+    customTemplate:
+      template: "{{.version}}-{{.sha}}"
+      components:
+        - name: version
+          envTemplate:
+            template: "{{.EXTENSION_VERSION}}"
+        - name: sha
+          inputDigest: {}
   artifacts:
     - image: local-skaffold/gardener-extension-shoot-rsyslog-relp-admission
       ko:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
This PR performs the following changes from the registry-cache extension which are applicable also to this extension:
- https://github.com/gardener/gardener-extension-registry-cache/pull/277
- https://github.com/gardener/gardener-extension-registry-cache/pull/279

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
An issue causing `make extension-up` to fail to patch the ControllerDeployment is now mitigated.
```

```bugfix developer
An issue causing `make extension-up` to do NOT generate a new tag for local source code changes is now fixed.
```

