### PR TITLE
Make decoding of `Raw` to configs consistent

### DIFF
--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -191,19 +191,6 @@ func isExtensionEnabled(ext *core.Extension) bool {
 	return true
 }
 
-func decodeRsyslogRelpConfig(decoder runtime.Decoder, config *runtime.RawExtension, fldPath *field.Path) (*rsyslog.RsyslogRelpConfig, error) {
-	if config == nil {
-		return nil, field.Required(fldPath, "Rsyslog relp configuration is required when using gardener-extension-shoot-rsyslog-relp")
-	}
-
-	rsyslogRelpConfig := &rsyslog.RsyslogRelpConfig{}
-	if err := runtime.DecodeInto(decoder, config.Raw, rsyslogRelpConfig); err != nil {
-		return nil, fmt.Errorf("could not decode rsyslog relp configuration: %w", err)
-	}
-
-	return rsyslogRelpConfig, nil
-}
-
 func getReferencedResourceName(shoot *core.Shoot, resourceKind, resourceName string) (string, error) {
 	if shoot != nil {
 		for _, ref := range shoot.Spec.Resources {

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -168,8 +168,8 @@ func validateAuditConfigMap(decoder runtime.Decoder, configMap *corev1.ConfigMap
 	}
 
 	auditdConfig := &rsyslog.Auditd{}
-	err := runtime.DecodeInto(decoder, []byte(auditdConfigString), auditdConfig)
-	if err != nil {
+
+	if err := runtime.DecodeInto(decoder, []byte(auditdConfigString), auditdConfig); err != nil {
 		return fmt.Errorf("could not decode 'data.%s' field of configMap %s: %w", constants.AuditdConfigMapDataKey, configMapKey.String(), err)
 	}
 	if err := validation.ValidateAuditd(auditdConfig).ToAggregate(); err != nil {

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -168,7 +168,6 @@ func validateAuditConfigMap(decoder runtime.Decoder, configMap *corev1.ConfigMap
 	}
 
 	auditdConfig := &rsyslog.Auditd{}
-
 	err := runtime.DecodeInto(decoder, []byte(auditdConfigString), auditdConfig)
 	if err != nil {
 		return fmt.Errorf("could not decode 'data.%s' field of configMap %s: %w", constants.AuditdConfigMapDataKey, configMapKey.String(), err)

--- a/pkg/cmd/rsyslogrelp/options.go
+++ b/pkg/cmd/rsyslogrelp/options.go
@@ -59,8 +59,7 @@ func (o *Options) Complete() error {
 	}
 
 	configuration := apisconfig.Configuration{}
-	err = runtime.DecodeInto(decoder, data, &configuration)
-	if err != nil {
+	if err = runtime.DecodeInto(decoder, data, &configuration); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/rsyslogrelp/options.go
+++ b/pkg/cmd/rsyslogrelp/options.go
@@ -59,7 +59,7 @@ func (o *Options) Complete() error {
 	}
 
 	configuration := apisconfig.Configuration{}
-	_, _, err = decoder.Decode(data, nil, &configuration)
+	err = runtime.DecodeInto(decoder, data, &configuration)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -58,7 +58,7 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, ex *extensionsv
 	namespace := ex.GetNamespace()
 
 	rsyslogRelpConfig := &api.RsyslogRelpConfig{}
-	if _, _, err := a.decoder.Decode(ex.Spec.ProviderConfig.Raw, nil, rsyslogRelpConfig); err != nil {
+	if err := runtime.DecodeInto(a.decoder, ex.Spec.ProviderConfig.Raw, rsyslogRelpConfig); err != nil {
 		return fmt.Errorf("failed to decode provider config: %w", err)
 	}
 

--- a/pkg/webhook/operatingsystemconfig/auditd.go
+++ b/pkg/webhook/operatingsystemconfig/auditd.go
@@ -72,7 +72,7 @@ func getAuditConfigFromConfigMap(ctx context.Context, c client.Client, decoder r
 	}
 
 	auditdConfig := &rsyslog.Auditd{}
-	_, _, err := decoder.Decode([]byte(auditdConfigString), nil, auditdConfig)
+	err := runtime.DecodeInto(decoder, []byte(auditdConfigString), auditdConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/webhook/operatingsystemconfig/ensurer.go
+++ b/pkg/webhook/operatingsystemconfig/ensurer.go
@@ -65,7 +65,7 @@ func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gctx gcontext.Garde
 
 	shootRsyslogRelpConfig := &rsyslog.RsyslogRelpConfig{}
 	if extension.Spec.ProviderConfig != nil {
-		if _, _, err := e.decoder.Decode(extension.Spec.ProviderConfig.Raw, nil, shootRsyslogRelpConfig); err != nil {
+		if err := runtime.DecodeInto(e.decoder, extension.Spec.ProviderConfig.Raw, shootRsyslogRelpConfig); err != nil {
 			return fmt.Errorf("failed to decode provider config: %w", err)
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
Whenever decoding is needed, it's now done using `runtime.DecodeInto()`.

**Which issue(s) this PR fixes**:
Fixes #202

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
