### PR TITLE
Promote `testmachinery` tests to GA

### DIFF
--- a/.test-defs/TestSuiteShootRsyslogRelpSerial.yaml
+++ b/.test-defs/TestSuiteShootRsyslogRelpSerial.yaml
@@ -1,13 +1,13 @@
 apiVersion: testmachinery.sapcloud.io
 kind: TestDefinition
 metadata:
-  name: shoot-rsyslog-relp-beta-serial-test-suite
+  name: shoot-rsyslog-relp-serial-test-suite
 spec:
   owner: gardener-oq@listserv.sap.com
-  description: shoot-rsyslog-relp extension test suite that includes all serial beta tests
+  description: shoot-rsyslog-relp extension test suite that includes all serial tests
 
   activeDeadlineSeconds: 16800
-  labels: ["shoot", "beta"]
+  labels: ["shoot"]
   behavior:
   - serial
 
@@ -19,7 +19,7 @@ spec:
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -project-namespace=$PROJECT_NAMESPACE
       -shoot-name=$SHOOT_NAME
-      -ginkgo.focus="\[BETA\].*\[SERIAL\]"
+      -ginkgo.focus="\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
       -ginkgo.timeout=16800s
 

--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 	}, time.Minute)
 
 	Context("shoot-rsyslog-relp extension with tls disabled", Label("tls-disabled"), func() {
-		f.Serial().Beta().CIt("should enable and disable the shoot-rsyslog-relp extension", func(parentCtx context.Context) {
+		f.Serial().CIt("should enable and disable the shoot-rsyslog-relp extension", func(parentCtx context.Context) {
 			test(parentCtx, defaultExtensionAuditRules, func(shoot *gardencorev1beta1.Shoot) error {
 				common.AddOrUpdateRsyslogRelpExtension(
 					shoot,
@@ -136,7 +136,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 		const secretReferenceName = "rsyslog-relp-tls"
 		var createdResources []client.Object
 
-		f.Serial().Beta().CIt("should enable and disable the shoot-rsyslog-relp extension", func(parentCtx context.Context) {
+		f.Serial().CIt("should enable and disable the shoot-rsyslog-relp extension", func(parentCtx context.Context) {
 			By("Create rsyslog-relp-tls Secret")
 			ctx, cancel := context.WithTimeout(parentCtx, 2*time.Minute)
 			defer cancel()
@@ -178,7 +178,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 		const configMapRefName = "audit-config"
 		var createdResources []client.Object
 
-		f.Serial().Beta().CIt("should enable and disable the shoot-rsyslog-relp extension", func(parentCtx context.Context) {
+		f.Serial().CIt("should enable and disable the shoot-rsyslog-relp extension", func(parentCtx context.Context) {
 			By("Create rsyslog-relp-tls Secret")
 			ctx, cancel := context.WithTimeout(parentCtx, 2*time.Minute)
 			defer cancel()

--- a/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
+++ b/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 
 	f := framework.NewShootFramework(nil)
 
-	f.Serial().Beta().CIt("should enable and disable the shoot-rsyslog-relp extension", func(parentCtx context.Context) {
+	f.Serial().CIt("should enable and disable the shoot-rsyslog-relp extension", func(parentCtx context.Context) {
 		By("Deploy the rsyslog-relp-echo-server in Shoot cluster")
 		ctx, cancel := context.WithTimeout(parentCtx, time.Minute)
 		defer cancel()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement


**What this PR does / why we need it**:
This PR promotes the testmachinery tests to "GA"  - it removes the beta labels from the tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The shoot-rsyslog-relp extension test-machinery tests are no longer beta.
```
