### PR TITLE
Fix tagging of extension image for remote dev setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ ci-e2e-kind: $(KIND) $(YQ)
 export SKAFFOLD_BUILD_CONCURRENCY = 0
 extension-up extension-dev: export SKAFFOLD_DEFAULT_REPO = garden.local.gardener.cloud:5001
 extension-up extension-dev: export SKAFFOLD_PUSH = true
-extension-up extension-dev: export EXTENSION_VERSION = $(VERSION)
+extension-up extension-dev remote-extension-up: export EXTENSION_VERSION = $(VERSION)
 # use static label for skaffold to prevent rolling all gardener components on every `skaffold` invocation
 extension-up extension-dev extension-down: export SKAFFOLD_LABEL = skaffold.dev/run-id=extension-local
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
When skaffold tags the `gardener-extension-shoot-rsyslog-relp` extension, it uses the `EXTENSION_VERSION` variable. However, that variable was not defined for the `make remote-extension-up` target which lead to the following error:
```
Generating tags...
 - local-skaffold/gardener-extension-shoot-rsyslog-relp -> reg.gcp-seed1.i077286.shoot.dev.k8s-hana.ondemand.com/local-skaffold_gardener-extension-shoot-rsyslog-relp:latest
Some taggers failed. Rerun with -vdebug for errors.
```

This PR defines the `EXTENSION_VERSION` variable for the `make remote-extension-up` target.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Fixed an issue that caused skaffold to fail to tag the `gardener-extension-shoot-rsyslog-relp` image during the execution of the `make remote-extension-up` command.
```
