### PR TITLE
Fixes reuse compliance

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -19,8 +19,10 @@ Files:
   VERSION
   charts/gardener-extension-shoot-rsyslog-relp/.helmignore
   charts/gardener-extension-shoot-rsyslog-relp/templates/_helpers.tpl
-  charts/gardener-extension-shoot-rsyslog-relp-admission/.helmignore
-  charts/gardener-extension-shoot-rsyslog-relp-admission/templates/_helpers.tpl
+  charts/gardener-extension-shoot-rsyslog-relp-admission/charts/application/.helmignore
+  charts/gardener-extension-shoot-rsyslog-relp-admission/charts/application/templates/_helpers.tpl
+  charts/gardener-extension-shoot-rsyslog-relp-admission/charts/runtime/.helmignore
+  charts/gardener-extension-shoot-rsyslog-relp-admission/charts/runtime/templates/_helpers.tpl
   example/extension/.gitignore
   example/extension/extension-config-patch.yaml.tmpl
   example/local/charts/rsyslog-relp-echo-server/.helmignore


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area compliance
/kind bug

**What this PR does / why we need it**:
This PR fixes the reuse compliance. The repo is currently not compliant because the `.reuse/dep5` file was  not updated in #228 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
