### PR TITLE
Add base for webhook integration test

### DIFF
--- a/test/integration/webhook/resources/crd-extensions.gardener.cloud_clusters.yaml
+++ b/test/integration/webhook/resources/crd-extensions.gardener.cloud_clusters.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: clusters.extensions.gardener.cloud
+spec:
+  group: extensions.gardener.cloud
+  names:
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    singular: cluster
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: creation timestamp
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Cluster is a specification for a Cluster resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSpec is the spec for a Cluster resource.
+            properties:
+              cloudProfile:
+                description: |-
+                  CloudProfile is a raw extension field that contains the cloudprofile resource referenced
+                  by the shoot that has to be reconciled.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              seed:
+                description: |-
+                  Seed is a raw extension field that contains the seed resource referenced by the shoot that
+                  has to be reconciled.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              shoot:
+                description: Shoot is a raw extension field that contains the shoot
+                  resource that has to be reconciled.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            required:
+            - cloudProfile
+            - seed
+            - shoot
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/test/integration/webhook/resources/crd-extensions.gardener.cloud_extensions.yaml
+++ b/test/integration/webhook/resources/crd-extensions.gardener.cloud_extensions.yaml
@@ -1,0 +1,234 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: extensions.extensions.gardener.cloud
+spec:
+  group: extensions.gardener.cloud
+  names:
+    kind: Extension
+    listKind: ExtensionList
+    plural: extensions
+    shortNames:
+    - ext
+    singular: extension
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The type of the Extension resource.
+      jsonPath: .spec.type
+      name: Type
+      type: string
+    - description: Status of Extension resource.
+      jsonPath: .status.lastOperation.state
+      name: Status
+      type: string
+    - description: creation timestamp
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Extension is a specification for a Extension resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the Extension.
+              If the object's deletion timestamp is set, this field is immutable.
+            properties:
+              class:
+                description: Class holds the extension class used to control the responsibility
+                  for multiple provider extensions.
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              providerConfig:
+                description: ProviderConfig is the provider specific configuration.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              type:
+                description: Type contains the instance of the resource's kind.
+                type: string
+            required:
+            - type
+            type: object
+          status:
+            description: ExtensionStatus is the status for a Extension resource.
+            properties:
+              conditions:
+                description: Conditions represents the latest available observations
+                  of a Seed's current state.
+                items:
+                  description: Condition holds the information about the state of
+                    a resource.
+                  properties:
+                    codes:
+                      description: Well-defined error codes in case the condition
+                        reports a problem.
+                      items:
+                        description: ErrorCode is a string alias.
+                        type: string
+                      type: array
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: Last time the condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of the condition.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - lastUpdateTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastError:
+                description: LastError holds information about the last occurred error
+                  during an operation.
+                properties:
+                  codes:
+                    description: Well-defined error codes of the last error(s).
+                    items:
+                      description: ErrorCode is a string alias.
+                      type: string
+                    type: array
+                  description:
+                    description: A human readable message indicating details about
+                      the last error.
+                    type: string
+                  lastUpdateTime:
+                    description: Last time the error was reported
+                    format: date-time
+                    type: string
+                  taskID:
+                    description: ID of the task which caused this last error
+                    type: string
+                required:
+                - description
+                type: object
+              lastOperation:
+                description: LastOperation holds information about the last operation
+                  on the resource.
+                properties:
+                  description:
+                    description: A human readable message indicating details about
+                      the last operation.
+                    type: string
+                  lastUpdateTime:
+                    description: Last time the operation state transitioned from one
+                      to another.
+                    format: date-time
+                    type: string
+                  progress:
+                    description: The progress in percentage (0-100) of the last operation.
+                    format: int32
+                    type: integer
+                  state:
+                    description: Status of the last operation, one of Aborted, Processing,
+                      Succeeded, Error, Failed.
+                    type: string
+                  type:
+                    description: Type of the last operation, one of Create, Reconcile,
+                      Delete, Migrate, Restore.
+                    type: string
+                required:
+                - description
+                - lastUpdateTime
+                - progress
+                - state
+                - type
+                type: object
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  for this resource.
+                format: int64
+                type: integer
+              providerStatus:
+                description: ProviderStatus contains provider-specific status.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              resources:
+                description: Resources holds a list of named resource references that
+                  can be referred to in the state by their names.
+                items:
+                  description: NamedResourceReference is a named reference to a resource.
+                  properties:
+                    name:
+                      description: Name of the resource reference.
+                      type: string
+                    resourceRef:
+                      description: ResourceRef is a reference to a resource.
+                      properties:
+                        apiVersion:
+                          description: apiVersion is the API version of the referent
+                          type: string
+                        kind:
+                          description: 'kind is the kind of the referent; More info:
+                            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'name is the name of the referent; More info:
+                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  required:
+                  - name
+                  - resourceRef
+                  type: object
+                type: array
+              state:
+                description: State can be filled by the operating controller with
+                  what ever data it needs.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/test/integration/webhook/resources/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/test/integration/webhook/resources/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -1,0 +1,640 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    gardener.cloud/deletion-protected: "true"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: operatingsystemconfigs.extensions.gardener.cloud
+spec:
+  group: extensions.gardener.cloud
+  names:
+    kind: OperatingSystemConfig
+    listKind: OperatingSystemConfigList
+    plural: operatingsystemconfigs
+    shortNames:
+    - osc
+    singular: operatingsystemconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The type of the operating system configuration.
+      jsonPath: .spec.type
+      name: Type
+      type: string
+    - description: The purpose of the operating system configuration.
+      jsonPath: .spec.purpose
+      name: Purpose
+      type: string
+    - description: Status of operating system configuration.
+      jsonPath: .status.lastOperation.state
+      name: Status
+      type: string
+    - description: creation timestamp
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OperatingSystemConfig is a specification for a OperatingSystemConfig
+          resource
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Specification of the OperatingSystemConfig.
+              If the object's deletion timestamp is set, this field is immutable.
+            properties:
+              class:
+                description: Class holds the extension class used to control the responsibility
+                  for multiple provider extensions.
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              criConfig:
+                description: CRI config is a structure contains configurations of
+                  the CRI library
+                properties:
+                  cgroupDriver:
+                    description: CgroupDriver configures the CRI's cgroup driver.
+                      Supported values are `cgroupfs` or `systemd`.
+                    type: string
+                  containerd:
+                    description: |-
+                      ContainerdConfig is the containerd configuration.
+                      Only to be set for OperatingSystemConfigs with purpose 'reconcile'.
+                    properties:
+                      plugins:
+                        description: Plugins configures the plugins section in containerd's
+                          config.toml.
+                        items:
+                          description: PluginConfig contains configuration values
+                            for the containerd plugins section.
+                          properties:
+                            op:
+                              description: Op is the operation for the given path.
+                                Possible values are 'add' and 'remove', defaults to
+                                'add'.
+                              type: string
+                            path:
+                              description: Path is a list of elements that construct
+                                the path in the plugins section.
+                              items:
+                                type: string
+                              type: array
+                            values:
+                              description: |-
+                                Values are the values configured at the given path. If defined, it is expected as json format:
+                                - A given json object will be put to the given path.
+                                - If not configured, only the table entry to be created.
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      registries:
+                        description: Registries configures the registry hosts for
+                          containerd.
+                        items:
+                          description: RegistryConfig contains registry configuration
+                            options.
+                          properties:
+                            hosts:
+                              description: |-
+                                Hosts are the registry hosts.
+                                It corresponds to the host fields in the `hosts.toml` file, see https://github.com/containerd/containerd/blob/c51463010e0682f76dfdc10edc095e6596e2764b/docs/hosts.md#host-fields-in-the-toml-table-format for more information.
+                              items:
+                                description: RegistryHost contains configuration values
+                                  for a registry host.
+                                properties:
+                                  caCerts:
+                                    description: CACerts are paths to public key certificates
+                                      used for TLS.
+                                    items:
+                                      type: string
+                                    type: array
+                                  capabilities:
+                                    description: |-
+                                      Capabilities determine what operations a host is
+                                      capable of performing. Defaults to
+                                       - pull
+                                       - resolve
+                                    items:
+                                      description: RegistryCapability specifies an
+                                        action a client can perform against a registry.
+                                      type: string
+                                    type: array
+                                  url:
+                                    description: URL is the endpoint address of the
+                                      registry mirror.
+                                    type: string
+                                required:
+                                - url
+                                type: object
+                              type: array
+                            readinessProbe:
+                              description: ReadinessProbe determines if host registry
+                                endpoints should be probed before they are added to
+                                the containerd config.
+                              type: boolean
+                            server:
+                              description: |-
+                                Server is the URL to registry server of this upstream.
+                                It corresponds to the server field in the `hosts.toml` file, see https://github.com/containerd/containerd/blob/c51463010e0682f76dfdc10edc095e6596e2764b/docs/hosts.md#server-field for more information.
+                              type: string
+                            upstream:
+                              description: Upstream is the upstream name of the registry.
+                              type: string
+                          required:
+                          - upstream
+                          type: object
+                        type: array
+                      sandboxImage:
+                        description: SandboxImage configures the sandbox image for
+                          containerd.
+                        type: string
+                    required:
+                    - sandboxImage
+                    type: object
+                  name:
+                    description: Name is a mandatory string containing the name of
+                      the CRI library. Supported values are `containerd`.
+                    enum:
+                    - containerd
+                    type: string
+                    x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
+                required:
+                - name
+                type: object
+              files:
+                description: Files is a list of files that should get written to the
+                  host's file system.
+                items:
+                  description: |-
+                    File is a file that should get written to the host's file system. The content can either be inlined or
+                    referenced from a secret in the same namespace.
+                  properties:
+                    content:
+                      description: Content describe the file's content.
+                      properties:
+                        imageRef:
+                          description: ImageRef describes a container image which
+                            contains a file.
+                          properties:
+                            filePathInImage:
+                              description: FilePathInImage contains the path in the
+                                image to the file that should be extracted.
+                              type: string
+                            image:
+                              description: Image contains the container image repository
+                                with tag.
+                              type: string
+                          required:
+                          - filePathInImage
+                          - image
+                          type: object
+                        inline:
+                          description: Inline is a struct that contains information
+                            about the inlined data.
+                          properties:
+                            data:
+                              description: Data is the file's data.
+                              type: string
+                            encoding:
+                              description: Encoding is the file's encoding (e.g. base64).
+                              type: string
+                          required:
+                          - data
+                          - encoding
+                          type: object
+                        secretRef:
+                          description: SecretRef is a struct that contains information
+                            about the referenced secret.
+                          properties:
+                            dataKey:
+                              description: DataKey is the key in the secret's `.data`
+                                field that should be read.
+                              type: string
+                            name:
+                              description: Name is the name of the secret.
+                              type: string
+                          required:
+                          - dataKey
+                          - name
+                          type: object
+                        transmitUnencoded:
+                          description: |-
+                            TransmitUnencoded set to true will ensure that the os-extension does not encode the file content when sent to the node.
+                            This for example can be used to manipulate the clear-text content before it reaches the node.
+                          type: boolean
+                      type: object
+                    path:
+                      description: Path is the path of the file system where the file
+                        should get written to.
+                      type: string
+                    permissions:
+                      description: |-
+                        Permissions describes with which permissions the file should get written to the file system.
+                        If no permissions are set, the operating system's defaults are used.
+                      format: int32
+                      type: integer
+                  required:
+                  - content
+                  - path
+                  type: object
+                type: array
+              providerConfig:
+                description: ProviderConfig is the provider specific configuration.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              purpose:
+                description: |-
+                  Purpose describes how the result of this OperatingSystemConfig is used by Gardener. Either it
+                  gets sent to the `Worker` extension controller to bootstrap a VM, or it is downloaded by the
+                  gardener-node-agent already running on a bootstrapped VM.
+                  This field is immutable.
+                type: string
+              type:
+                description: Type contains the instance of the resource's kind.
+                type: string
+              units:
+                description: Units is a list of unit for the operating system configuration
+                  (usually, a systemd unit).
+                items:
+                  description: Unit is a unit for the operating system configuration
+                    (usually, a systemd unit).
+                  properties:
+                    command:
+                      description: Command is the unit's command.
+                      type: string
+                    content:
+                      description: Content is the unit's content.
+                      type: string
+                    dropIns:
+                      description: DropIns is a list of drop-ins for this unit.
+                      items:
+                        description: DropIn is a drop-in configuration for a systemd
+                          unit.
+                        properties:
+                          content:
+                            description: Content is the content of the drop-in.
+                            type: string
+                          name:
+                            description: Name is the name of the drop-in.
+                            type: string
+                        required:
+                        - content
+                        - name
+                        type: object
+                      type: array
+                    enable:
+                      description: Enable describes whether the unit is enabled or
+                        not.
+                      type: boolean
+                    filePaths:
+                      description: |-
+                        FilePaths is a list of files the unit depends on. If any file changes a restart of the dependent unit will be
+                        triggered. For each FilePath there must exist a File with matching Path in OperatingSystemConfig.Spec.Files.
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      description: Name is the name of a unit.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - purpose
+            - type
+            type: object
+          status:
+            description: OperatingSystemConfigStatus is the status for a OperatingSystemConfig
+              resource.
+            properties:
+              cloudConfig:
+                description: |-
+                  CloudConfig is a structure for containing the generated output for the given operating system
+                  config spec. It contains a reference to a secret as the result may contain confidential data.
+                  After Gardener v1.112, this will be only set for OperatingSystemConfigs with purpose 'provision'.
+                properties:
+                  secretRef:
+                    description: SecretRef is a reference to a secret that contains
+                      the actual result of the generated cloud config.
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - secretRef
+                type: object
+              conditions:
+                description: Conditions represents the latest available observations
+                  of a Seed's current state.
+                items:
+                  description: Condition holds the information about the state of
+                    a resource.
+                  properties:
+                    codes:
+                      description: Well-defined error codes in case the condition
+                        reports a problem.
+                      items:
+                        description: ErrorCode is a string alias.
+                        type: string
+                      type: array
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: Last time the condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of the condition.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - lastUpdateTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              extensionFiles:
+                description: ExtensionFiles is a list of additional files provided
+                  by the extension.
+                items:
+                  description: |-
+                    File is a file that should get written to the host's file system. The content can either be inlined or
+                    referenced from a secret in the same namespace.
+                  properties:
+                    content:
+                      description: Content describe the file's content.
+                      properties:
+                        imageRef:
+                          description: ImageRef describes a container image which
+                            contains a file.
+                          properties:
+                            filePathInImage:
+                              description: FilePathInImage contains the path in the
+                                image to the file that should be extracted.
+                              type: string
+                            image:
+                              description: Image contains the container image repository
+                                with tag.
+                              type: string
+                          required:
+                          - filePathInImage
+                          - image
+                          type: object
+                        inline:
+                          description: Inline is a struct that contains information
+                            about the inlined data.
+                          properties:
+                            data:
+                              description: Data is the file's data.
+                              type: string
+                            encoding:
+                              description: Encoding is the file's encoding (e.g. base64).
+                              type: string
+                          required:
+                          - data
+                          - encoding
+                          type: object
+                        secretRef:
+                          description: SecretRef is a struct that contains information
+                            about the referenced secret.
+                          properties:
+                            dataKey:
+                              description: DataKey is the key in the secret's `.data`
+                                field that should be read.
+                              type: string
+                            name:
+                              description: Name is the name of the secret.
+                              type: string
+                          required:
+                          - dataKey
+                          - name
+                          type: object
+                        transmitUnencoded:
+                          description: |-
+                            TransmitUnencoded set to true will ensure that the os-extension does not encode the file content when sent to the node.
+                            This for example can be used to manipulate the clear-text content before it reaches the node.
+                          type: boolean
+                      type: object
+                    path:
+                      description: Path is the path of the file system where the file
+                        should get written to.
+                      type: string
+                    permissions:
+                      description: |-
+                        Permissions describes with which permissions the file should get written to the file system.
+                        If no permissions are set, the operating system's defaults are used.
+                      format: int32
+                      type: integer
+                  required:
+                  - content
+                  - path
+                  type: object
+                type: array
+              extensionUnits:
+                description: ExtensionUnits is a list of additional systemd units
+                  provided by the extension.
+                items:
+                  description: Unit is a unit for the operating system configuration
+                    (usually, a systemd unit).
+                  properties:
+                    command:
+                      description: Command is the unit's command.
+                      type: string
+                    content:
+                      description: Content is the unit's content.
+                      type: string
+                    dropIns:
+                      description: DropIns is a list of drop-ins for this unit.
+                      items:
+                        description: DropIn is a drop-in configuration for a systemd
+                          unit.
+                        properties:
+                          content:
+                            description: Content is the content of the drop-in.
+                            type: string
+                          name:
+                            description: Name is the name of the drop-in.
+                            type: string
+                        required:
+                        - content
+                        - name
+                        type: object
+                      type: array
+                    enable:
+                      description: Enable describes whether the unit is enabled or
+                        not.
+                      type: boolean
+                    filePaths:
+                      description: |-
+                        FilePaths is a list of files the unit depends on. If any file changes a restart of the dependent unit will be
+                        triggered. For each FilePath there must exist a File with matching Path in OperatingSystemConfig.Spec.Files.
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      description: Name is the name of a unit.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              lastError:
+                description: LastError holds information about the last occurred error
+                  during an operation.
+                properties:
+                  codes:
+                    description: Well-defined error codes of the last error(s).
+                    items:
+                      description: ErrorCode is a string alias.
+                      type: string
+                    type: array
+                  description:
+                    description: A human readable message indicating details about
+                      the last error.
+                    type: string
+                  lastUpdateTime:
+                    description: Last time the error was reported
+                    format: date-time
+                    type: string
+                  taskID:
+                    description: ID of the task which caused this last error
+                    type: string
+                required:
+                - description
+                type: object
+              lastOperation:
+                description: LastOperation holds information about the last operation
+                  on the resource.
+                properties:
+                  description:
+                    description: A human readable message indicating details about
+                      the last operation.
+                    type: string
+                  lastUpdateTime:
+                    description: Last time the operation state transitioned from one
+                      to another.
+                    format: date-time
+                    type: string
+                  progress:
+                    description: The progress in percentage (0-100) of the last operation.
+                    format: int32
+                    type: integer
+                  state:
+                    description: Status of the last operation, one of Aborted, Processing,
+                      Succeeded, Error, Failed.
+                    type: string
+                  type:
+                    description: Type of the last operation, one of Create, Reconcile,
+                      Delete, Migrate, Restore.
+                    type: string
+                required:
+                - description
+                - lastUpdateTime
+                - progress
+                - state
+                - type
+                type: object
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  for this resource.
+                format: int64
+                type: integer
+              providerStatus:
+                description: ProviderStatus contains provider-specific status.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              resources:
+                description: Resources holds a list of named resource references that
+                  can be referred to in the state by their names.
+                items:
+                  description: NamedResourceReference is a named reference to a resource.
+                  properties:
+                    name:
+                      description: Name of the resource reference.
+                      type: string
+                    resourceRef:
+                      description: ResourceRef is a reference to a resource.
+                      properties:
+                        apiVersion:
+                          description: apiVersion is the API version of the referent
+                          type: string
+                        kind:
+                          description: 'kind is the kind of the referent; More info:
+                            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'name is the name of the referent; More info:
+                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  required:
+                  - name
+                  - resourceRef
+                  type: object
+                type: array
+              state:
+                description: State can be filled by the operating controller with
+                  what ever data it needs.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/test/integration/webhook/webhook_suite_test.go
+++ b/test/integration/webhook/webhook_suite_test.go
@@ -1,0 +1,205 @@
+package webhook_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	webhookcmd "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+
+	rsyslogrelpcmd "github.com/gardener/gardener-extension-shoot-rsyslog-relp/pkg/cmd/rsyslogrelp"
+	"github.com/gardener/gardener-extension-shoot-rsyslog-relp/pkg/constants"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/logger"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	controllerconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+func TestWebhook(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Integration Webhook Suite")
+}
+
+const (
+	testID       = "webhook-test"
+	providerName = "test-provider"
+)
+
+var (
+	ctx = context.TODO()
+	log logr.Logger
+
+	restConfig *rest.Config
+	testEnv    *envtest.Environment
+	testClient client.Client
+
+	cluster *extensionsv1alpha1.Cluster
+
+	testNamespace *corev1.Namespace
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	log = logf.Log.WithName(testID)
+
+	By("Start test environment")
+	testEnv = &envtest.Environment{
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("resources", "crd-extensions.gardener.cloud_extensions.yaml"),
+				filepath.Join("resources", "crd-extensions.gardener.cloud_operatingsystemconfigs.yaml"),
+				filepath.Join("resources", "crd-extensions.gardener.cloud_clusters.yaml"),
+			},
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	restConfig, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(restConfig).NotTo(BeNil())
+
+	DeferCleanup(func() {
+		By("Stop test environment")
+		Expect(testEnv.Stop()).To(Succeed())
+	})
+
+	By("Create test client")
+	testClient, err = client.New(restConfig, client.Options{Scheme: kubernetes.SeedScheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Create test Namespace")
+	testNamespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			// create dedicated namespace for each test run, so that we can run multiple tests concurrently for stress tests
+			GenerateName: testID + "-",
+			Labels: map[string]string{
+				v1beta1constants.LabelExtensionPrefix + constants.ExtensionType: "true",
+			},
+		},
+	}
+	Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
+	log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
+
+	DeferCleanup(func() {
+		By("Delete test Namespace")
+		Expect(testClient.Delete(ctx, testNamespace)).To(Or(Succeed(), BeNotFoundError()))
+	})
+
+	By("Setup manager")
+	mgr, err := manager.New(restConfig, manager.Options{
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Port:    testEnv.WebhookInstallOptions.LocalServingPort,
+			Host:    testEnv.WebhookInstallOptions.LocalServingHost,
+			CertDir: testEnv.WebhookInstallOptions.LocalServingCertDir,
+		}),
+		Scheme:  kubernetes.SeedScheme,
+		Metrics: metricsserver.Options{BindAddress: "0"},
+		Cache: cache.Options{
+			DefaultNamespaces: map[string]cache.Config{testNamespace.Name: {}},
+		},
+		Controller: controllerconfig.Controller{
+			SkipNameValidation: ptr.To(true),
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Register webhook")
+	Expect(addTestWebhookToManager(mgr)).To(Succeed())
+
+	By("Start manager")
+	mgrContext, mgrCancel := context.WithCancel(ctx)
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(mgrContext)).To(Succeed())
+	}()
+
+	DeferCleanup(func() {
+		By("Stop manager")
+		mgrCancel()
+	})
+
+	By("Wait for MutatingWebhookConfiguration")
+	Eventually(func() error {
+		return testClient.Get(ctx, client.ObjectKey{Name: "gardener-extension-shoot-rsyslog-relp"}, &admissionregistrationv1.MutatingWebhookConfiguration{})
+	}).Should(Succeed())
+
+	By("Create Cluster")
+
+	shoot := &gardencorev1beta1.Shoot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: testNamespace.Name,
+		},
+		Spec: gardencorev1beta1.ShootSpec{
+			Kubernetes: gardencorev1beta1.Kubernetes{
+				Version: "1.27.0",
+			},
+		},
+	}
+	shootJSON, err := json.Marshal(shoot)
+	Expect(err).To(Succeed())
+	cluster = &extensionsv1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNamespace.Name,
+		},
+		Spec: extensionsv1alpha1.ClusterSpec{
+			CloudProfile: runtime.RawExtension{Raw: []byte("{}")},
+			Seed:         runtime.RawExtension{Raw: []byte("{}")},
+			Shoot:        runtime.RawExtension{Raw: shootJSON},
+		},
+	}
+
+	Expect(testClient.Create(ctx, cluster)).To(Succeed())
+	log.Info("Created Cluster for test", "cluster", client.ObjectKeyFromObject(cluster))
+
+	DeferCleanup(func() {
+		By("Delete Cluster")
+		Expect(client.IgnoreNotFound(testClient.Delete(ctx, cluster))).To(Succeed())
+	})
+
+})
+
+func addTestWebhookToManager(mgr manager.Manager) error {
+	webhookSwitches := rsyslogrelpcmd.WebhookSwitchOptions()
+	webhookOptions := webhookcmd.NewAddToManagerOptions(
+		"shoot-rsyslog-relp",
+		"",
+		nil,
+		&webhookcmd.ServerOptions{
+			Mode: extensionswebhook.ModeURL,
+			URL:  fmt.Sprintf("%s:%d", testEnv.WebhookInstallOptions.LocalServingHost, testEnv.WebhookInstallOptions.LocalServingPort),
+		},
+		webhookSwitches,
+	)
+	if err := webhookOptions.Complete(); err != nil {
+		return err
+	}
+	_, err := webhookOptions.Completed().AddToManager(ctx, mgr, nil)
+	return err
+}

--- a/test/integration/webhook/webhook_test.go
+++ b/test/integration/webhook/webhook_test.go
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package webhook_test
+
+import (
+	_ "embed"
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener-extension-shoot-rsyslog-relp/pkg/apis/rsyslog"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+)
+
+// //go:embed testdata/*
+// var testdata embed.FS
+
+var _ = Describe("Webhook tests", func() {
+	var (
+		osc    *extensionsv1alpha1.OperatingSystemConfig
+		config *rsyslog.RsyslogRelpConfig
+	)
+
+	JustBeforeEach(func() {
+		By("Create Extension")
+		extensionProviderConfigJSON, err := json.Marshal(config)
+		Expect(err).NotTo(HaveOccurred())
+		extension := &extensionsv1alpha1.Extension{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shoot-rsyslog-relp",
+				Namespace: cluster.ObjectMeta.Name,
+			},
+			Spec: extensionsv1alpha1.ExtensionSpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					ProviderConfig: &runtime.RawExtension{
+						Raw: extensionProviderConfigJSON,
+					},
+				},
+			},
+		}
+		Expect(testClient.Create(ctx, extension)).To(Succeed())
+		log.Info("Created Extension", "cluster", client.ObjectKeyFromObject(extension))
+		DeferCleanup(func() {
+			By("Delete Extension")
+			Expect(client.IgnoreNotFound(testClient.Delete(ctx, extension))).To(Succeed())
+		})
+
+		osc = &extensionsv1alpha1.OperatingSystemConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-osc",
+				Namespace: testNamespace.Name,
+			},
+			Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					Type:           "",
+					ProviderConfig: &runtime.RawExtension{},
+				},
+				Purpose: extensionsv1alpha1.OperatingSystemConfigPurposeReconcile,
+				Units: []extensionsv1alpha1.Unit{
+					{
+						Name: "foo",
+						DropIns: []extensionsv1alpha1.DropIn{
+							{
+								Name:    "drop1",
+								Content: "data1",
+							},
+						},
+						FilePaths: []string{"/foo-bar-file"},
+					},
+				},
+				Files: []extensionsv1alpha1.File{
+					{
+						Path: "foo/bar",
+						Content: extensionsv1alpha1.FileContent{
+							Inline: &extensionsv1alpha1.FileContentInline{
+								Encoding: "b64",
+								Data:     "some-data",
+							},
+						},
+					},
+					{
+						Path: "/foo-bar-file",
+						Content: extensionsv1alpha1.FileContent{
+							ImageRef: &extensionsv1alpha1.FileContentImageRef{
+								Image:           "foo-image:bar-tag",
+								FilePathInImage: "/foo-bar-file",
+							},
+						},
+					},
+				},
+			},
+		}
+		By("Create OSC")
+		// we use Eventually because webhook may still not be ready to receive traffic
+		Eventually(func() error {
+			return testClient.Create(ctx, osc)
+		}).Should(Succeed())
+		DeferCleanup(func() {
+			By("Delete OSC")
+			Expect(client.IgnoreNotFound(testClient.Delete(ctx, osc))).To(Succeed())
+		})
+
+	})
+
+	Context("TODO", func() {
+		BeforeEach(func() {
+			config = &rsyslog.RsyslogRelpConfig{}
+		})
+
+		It("TODO", func() {
+			//	_, _ = testdata.ReadFile("path/to/foo")
+		})
+	})
+
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind test

**What this PR does / why we need it**:
This PR adds the base for webhook integration test. In contrast to e2e test, integration tests are more lightweight, faster and easier to navigate using a debugger as there are less moving parts

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
