### PR TITLE
Explicitly disable audit configuration for local setup and e2e tests

### DIFF
--- a/example/shoot.yaml
+++ b/example/shoot.yaml
@@ -19,6 +19,10 @@ spec:
       target: 10.2.64.54
       port: 80
     # port: 443 # Use this port if you plan on enabling tls.
+      auditConfig:
+      # explicitly disable configuration of audit rules for local setup because the audit system does not work in the local shoot's machine
+        enabled: false
+      # configMapReferenceName: audit-config
       loggingRules:
       # only forward logs from systemd that are at Info(6) syslog severity or below to the target server
       - severity: 6
@@ -28,8 +32,6 @@ spec:
         #   regex: "foo"
         #   exclude: "bar"
       # only forward logs from download-cloud-config.sh that are at Debug(7) syslog severity or below to the target server
-      - severity: 7
-        programNames: ["download-cloud-config.sh"]
       resumeRetryCount: -1 # never discard logs if the target server is not available
     # timeout: 90
     # rebindInterval: 1000
@@ -41,9 +43,6 @@ spec:
     #   tlsLib: openssl # {openssl, gnutls}
     #   permittedPeer:
     #   - "rsyslog-server"
-    # auditConfig:
-    #   enabled: true
-    #   configMapReferenceName: audit-config
 # resources:
 # - name: rsyslog-tls-certificates
 #   resourceRef:

--- a/test/e2e/create_enable_disable_delete.go
+++ b/test/e2e/create_enable_disable_delete.go
@@ -84,7 +84,7 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 		f.Shoot = e2e.DefaultShoot("e2e-rslog-relp")
 
 		enableExtensionFunc := func(shoot *gardencorev1beta1.Shoot) error {
-			common.AddOrUpdateRsyslogRelpExtension(shoot)
+			common.AddOrUpdateRsyslogRelpExtension(shoot, common.WithAuditConfig(&v1alpha1.AuditConfig{Enabled: false}))
 			return nil
 		}
 
@@ -97,7 +97,7 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 		f.Shoot = e2e.DefaultShoot("e2e-rslog-tls")
 
 		enableExtensionFunc := func(shoot *gardencorev1beta1.Shoot) error {
-			common.AddOrUpdateRsyslogRelpExtension(shoot, common.WithPort(443), common.WithTLSWithSecretRefNameAndTLSLib("rsyslog-relp-tls", "openssl"))
+			common.AddOrUpdateRsyslogRelpExtension(shoot, common.WithPort(443), common.WithTLSWithSecretRefNameAndTLSLib("rsyslog-relp-tls", "openssl"), common.WithAuditConfig(&v1alpha1.AuditConfig{Enabled: false}))
 			common.AddOrUpdateResourceReference(shoot, "rsyslog-relp-tls", "Secret", createdResources[0].GetName())
 			return nil
 		}
@@ -134,7 +134,6 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 			{Program: "filter-program", Severity: "3", Message: "this excluded log should not get sent to echo server", ShouldBeForwarded: false},
 		}
 		enableExtensionFunc := func(shoot *gardencorev1beta1.Shoot) error {
-			common.AddOrUpdateRsyslogRelpExtension(shoot)
 			loggingRule := v1alpha1.LoggingRule{
 				ProgramNames: []string{"filter-program"},
 				Severity:     ptr.To(3),
@@ -144,7 +143,7 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 				},
 			}
 
-			common.AddOrUpdateRsyslogRelpExtension(shoot, common.AppendLoggingRule(loggingRule))
+			common.AddOrUpdateRsyslogRelpExtension(shoot, common.AppendLoggingRule(loggingRule), common.WithAuditConfig(&v1alpha1.AuditConfig{Enabled: false}))
 			return nil
 		}
 

--- a/test/e2e/create_enable_force_delete.go
+++ b/test/e2e/create_enable_force_delete.go
@@ -13,13 +13,14 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/gardener/gardener-extension-shoot-rsyslog-relp/pkg/apis/rsyslog/v1alpha1"
 	"github.com/gardener/gardener-extension-shoot-rsyslog-relp/test/common"
 )
 
 var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 	f := defaultShootCreationFramework()
 	f.Shoot = e2e.DefaultShoot("e2e-rslog-fd")
-	common.AddOrUpdateRsyslogRelpExtension(f.Shoot)
+	common.AddOrUpdateRsyslogRelpExtension(f.Shoot, common.WithAuditConfig(&v1alpha1.AuditConfig{Enabled: false}))
 
 	It("Create Shoot with shoot-rsyslog-relp extension enabled and force delete Shoot", Label("force-delete"), func() {
 		ctx, cancel := context.WithTimeout(parentCtx, 20*time.Minute)

--- a/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
+++ b/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
@@ -13,13 +13,14 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/gardener/gardener-extension-shoot-rsyslog-relp/pkg/apis/rsyslog/v1alpha1"
 	"github.com/gardener/gardener-extension-shoot-rsyslog-relp/test/common"
 )
 
 var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 	f := defaultShootCreationFramework()
 	f.Shoot = e2e.DefaultShoot("e2e-rslog-hib")
-	common.AddOrUpdateRsyslogRelpExtension(f.Shoot)
+	common.AddOrUpdateRsyslogRelpExtension(f.Shoot, common.WithAuditConfig(&v1alpha1.AuditConfig{Enabled: false}))
 
 	It("Create Shoot with shoot-rsyslog-relp extension enabled, hibernate Shoot, reconcile Shoot, wake up Shoot, delete Shoot", Label("hibernation"), func() {
 		By("Create Shoot")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind enhancement

**What this PR does / why we need it**:
This PR explicitly disables the configuration of `auditd` and audit rules for e2e tests and the local setup.
Generally, there is a check in the script that sets up `auditd` and `rsyslog` which should skip setting up `auditd` if it does not exist on the system: [ref](https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/blob/f88721571a0c5e722c558c53411b40716f6628be/pkg/webhook/operatingsystemconfig/resources/templates/scripts/configure-rsyslog.tpl.sh#L133-L138). However, this check is not consistent during the local setup - the check will sometimes detect that `auditd` is not installed, and sometimes that it is installed before trying to configure `rsyslog`. If `rsyslog` gets installed before `auditd`, then `rsyslog` will be configured properly, however if `auditd` is installed first, the script errors when trying to restart it and never tries to configure `rsyslog`. The following error describes what happens when we try to (re)start `auditd` in a local shoot's machine:
```bash
Mar 20 10:05:50 machine-shoot--local--local-local-6cffc-sjn8h systemd[1]: Starting auditd.service - Security Auditing Service...
Mar 20 10:05:50 machine-shoot--local--local-local-6cffc-sjn8h auditd[9339]: audit dispatcher initialized with q_depth=2000 and 1 active plugins
Mar 20 10:05:50 machine-shoot--local--local-local-6cffc-sjn8h auditd[9339]: Error sending status request (Operation not permitted)
Mar 20 10:05:50 machine-shoot--local--local-local-6cffc-sjn8h auditd[9339]: Error sending enable request (Operation not permitted)
Mar 20 10:05:50 machine-shoot--local--local-local-6cffc-sjn8h auditd[9339]: Unable to set initial audit startup state to 'enable', exiting
Mar 20 10:05:50 machine-shoot--local--local-local-6cffc-sjn8h audisp-syslog[9341]: syslog plugin initialized with facility 8 and priority 6
Mar 20 10:05:50 machine-shoot--local--local-local-6cffc-sjn8h audisp-syslog[9341]: type=DAEMON_START msg=audit(1742465150.702:2042): op=start ver=3.0.9 format=enriched kernel=6.10.14-linuxkit auid=4294967295 pid=9339 uid=0 ses=4294967295 res=success AUID="unset" UID="root"
Mar 20 10:05:50 machine-shoot--local--local-local-6cffc-sjn8h audisp-syslog[9341]: type=DAEMON_ABORT msg=audit(1742465150.703:2043): op=set-enable auid=4294967295 pid=9339 uid=0 ses=4294967295 res=failed AUID="unset" UID="root"
Mar 20 10:05:50 machine-shoot--local--local-local-6cffc-sjn8h auditd[9339]: The audit daemon is exiting.
Mar 20 10:05:50 machine-shoot--local--local-local-6cffc-sjn8h auditd[9339]: Error setting audit daemon pid (Operation not permitted)
Mar 20 10:05:50 machine-shoot--local--local-local-6cffc-sjn8h auditd[9338]: Cannot daemonize (Success)
Mar 20 10:05:50 machine-shoot--local--local-local-6cffc-sjn8h auditd[9338]: The audit daemon is exiting.
```

Additionally (to clean up the `shoot.yaml` file),  the PR removes forwarding logs for the `download-cloud-config.sh` script as it is now replaced by `gardener-node-agent`

**Which issue(s) this PR fixes**:
Fixes 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
