### PR TITLE
Bring back tm beta labels so that tests can be properly GAed

### DIFF
--- a/.test-defs/TestSuiteShootRsyslogRelpSerial.yaml
+++ b/.test-defs/TestSuiteShootRsyslogRelpSerial.yaml
@@ -7,6 +7,7 @@ spec:
   description: shoot-rsyslog-relp extension test suite that includes all serial tests
 
   activeDeadlineSeconds: 16800
+  labels: ["shoot", "beta"]
   behavior:
   - serial
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind enhancement

**What this PR does / why we need it**:
This PR brings back the `beta` and `shoot` labels to the TM test definition. This is currently necessary because our test landscapes use the `IstioTLSTermination` feature gate which requires changes in the `RootPodExecutor` interface used by the `shoot-rsyslog-relp` tests. Those changes come in g/g `v1.114`. 
Without these labels, when the tests are executed on the landscapes, they are picked from the `v0.7.0` release of the `shoot-rsyslog-relp` extension which does not have the required changes to work with `IstioTLSTermination`. Adding these labels will let TM find the test definitions from the `main` branch of this repository and use them.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
