### PR TITLE
Remove `shoot` and `beta` labels from test defs

### DIFF
--- a/.test-defs/TestSuiteShootRsyslogRelpSerial.yaml
+++ b/.test-defs/TestSuiteShootRsyslogRelpSerial.yaml
@@ -7,7 +7,6 @@ spec:
   description: shoot-rsyslog-relp extension test suite that includes all serial tests
 
   activeDeadlineSeconds: 16800
-  labels: ["shoot", "beta"]
   behavior:
   - serial
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind cleanup

**What this PR does / why we need it**:
This PR removes the `shoot` and `beta` labels from the `TestSuiteShootRsyslogRelpSerial.yaml` test definition. 
The test definition is now referenced by name directly from our testing infrastructure so the labels are no-longer necessary.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
