### PR TITLE
Execute `augenrules --load` only when necessary

### DIFF
--- a/pkg/webhook/operatingsystemconfig/resources/templates/scripts/configure-rsyslog.tpl.sh
+++ b/pkg/webhook/operatingsystemconfig/resources/templates/scripts/configure-rsyslog.tpl.sh
@@ -60,7 +60,7 @@ function configure_auditd() {
   # This check is temporarily necessary for nodes on which the `configure-rsyslog.sh` script already ran and
   # the audit rules were configured, but the $auditd_metrics_file was not created because its parent dir was missing.
   # Reference: https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/pull/256
-  if [ "${restart_auditd}" ] || [[ ! -f "${auditd_metrics_file}" ]]; then
+  if [ "${restart_auditd}" = true ] || [[ ! -f "${auditd_metrics_file}" ]]; then
     if [[ ! -d {{ .nodeExporterTextfileCollectorDir }} ]]; then
       mkdir -p "{{ .nodeExporterTextfileCollectorDir }}"
     fi

--- a/pkg/webhook/operatingsystemconfig/testdata/configure-rsyslog.sh
+++ b/pkg/webhook/operatingsystemconfig/testdata/configure-rsyslog.sh
@@ -60,7 +60,7 @@ function configure_auditd() {
   # This check is temporarily necessary for nodes on which the `configure-rsyslog.sh` script already ran and
   # the audit rules were configured, but the $auditd_metrics_file was not created because its parent dir was missing.
   # Reference: https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/pull/256
-  if [ "${restart_auditd}" ] || [[ ! -f "${auditd_metrics_file}" ]]; then
+  if [ "${restart_auditd}" = true ] || [[ ! -f "${auditd_metrics_file}" ]]; then
     if [[ ! -d /var/lib/node-exporter/textfile-collector ]]; then
       mkdir -p "/var/lib/node-exporter/textfile-collector"
     fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind bug

**What this PR does / why we need it**:
This PR fixes the `configure-rsyslog.sh` so that `augenrules --load` is executed only if the audit rules have changed or if the file that tracks if `augenrules --load` ran successfully is missing. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed an issue that caused `augenrules --load` to be executed every time the `configure-rsyslog.sh` script runs instead of only when audit rules have changed.
```
