### PR TITLE
tm tests: Add expectation framework's Shoot client not to be nil

### DIFF
--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -99,6 +99,8 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 	}
 
 	framework.CBeforeEach(func(ctx context.Context) {
+		Expect(f.ShootClient).NotTo(BeNil(), "Shoot client should not be nil. If it is the Shoot might be hibernated")
+
 		By("Deploy rsyslog-relp-echo-server in Shoot cluster")
 		var err error
 		echoServerIP, err = createRsyslogRelpEchoServer(ctx, f)
@@ -106,6 +108,8 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 	}, time.Minute)
 
 	framework.CAfterEach(func(ctx context.Context) {
+		Expect(f.ShootClient).NotTo(BeNil(), "Shoot client should not be nil. If it is the Shoot might be hibernated")
+
 		By("Delete rsyslog-relp-echo-server from Shoot cluster")
 		Expect(deleteRsyslogRelpEchoServer(ctx, f)).To(Succeed())
 	}, time.Minute)

--- a/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
+++ b/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
@@ -61,8 +61,8 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 		By("Hibernate Shoot")
 		ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
 		defer cancel()
-		Expect(f.HibernateShoot(ctx)).To(Succeed())
 		isShootHibernated = true
+		Expect(f.HibernateShoot(ctx)).To(Succeed())
 
 		By("Reconcile Shoot")
 		ctx, cancel = context.WithTimeout(parentCtx, 5*time.Minute)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Some executions of TM tests leave the TM Shoot in hibernated state.
When our TM tests are executed against such hibernated Shoot, they fail with:

```
• [PANICKED] [455.387 seconds]
 Shoot rsyslog-relp testing  [It] [SERIAL] [SHOOT] should enable and disable the shoot-rsyslog-relp extension
 /go/pkg/mod/github.com/gardener/gardener@v1.118.0/test/framework/gingko_utils.go:16
 
   [PANICKED] Test Panicked
   In [It] at: /usr/local/go/src/runtime/panic.go:262 @ 05/09/25 05:58:16.826
 
   runtime error: invalid memory address or nil pointer dereference
 
   Full Stack Trace
     github.com/gardener/gardener-extension-shoot-rsyslog-relp/test/testmachinery/shoot_test.createRsyslogRelpEchoServer({0x2baa718, 0xc0002e68c0}, 0xc0002fe8c0)
     	/src/test/testmachinery/shoot/common_test.go:33 +0x70
     github.com/gardener/gardener-extension-shoot-rsyslog-relp/test/testmachinery/shoot_test.init.func2.1({0x2baa718, 0xc0002e67e0})
     	/src/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go:34 +0xb3
     github.com/gardener/gardener/test/framework.CIt.contextify.func1()
     	/go/pkg/mod/github.com/gardener/gardener@v1.118.0/test/framework/gingko_utils.go:54 +0x4f
```

This PR makes the test fail in a better way with a proper message instead of a nil pointer panic when we receive such a hibernated Shoot from the test machinery.

This is similar to https://github.com/gardener/gardener-extension-registry-cache/pull/399, you can check that PR for more details.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ialidzhikov @dimitar-kostadinov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
