### PR TITLE
Drop support for Shoots with Kubernetes version <= 1.28

### DIFF
--- a/pkg/webhook/operatingsystemconfig/ensurer_test.go
+++ b/pkg/webhook/operatingsystemconfig/ensurer_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Ensurer", func() {
 					Workers: []gardencorev1beta1.Worker{{Name: "worker"}},
 				},
 				Kubernetes: gardencorev1beta1.Kubernetes{
-					Version: "1.27.2",
+					Version: "1.29.0",
 				},
 			},
 		}

--- a/test/integration/controller/lifecycle/lifecycle_test.go
+++ b/test/integration/controller/lifecycle/lifecycle_test.go
@@ -204,7 +204,7 @@ fi`,
 					Workers: []gardencorev1beta1.Worker{{Name: "worker"}},
 				},
 				Kubernetes: gardencorev1beta1.Kubernetes{
-					Version: "1.27.2",
+					Version: "1.29.0",
 				},
 				Resources: []gardencorev1beta1.NamedResourceReference{
 					{

--- a/test/integration/webhook/operatingsystemconfig/operatingsystemconfig_suite_test.go
+++ b/test/integration/webhook/operatingsystemconfig/operatingsystemconfig_suite_test.go
@@ -160,7 +160,7 @@ var _ = BeforeSuite(func() {
 		},
 		Spec: gardencorev1beta1.ShootSpec{
 			Kubernetes: gardencorev1beta1.Kubernetes{
-				Version: "1.27.0",
+				Version: "1.29.0",
 			},
 		},
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/area quality

**What this PR does / why we need it**:
Drop support for Shoots, Seeds and Gardens with Kubernetes version <= 1.28.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/12409

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
`shoot-rsyslog-relp` no longer supports Shoots with Кubernetes version <= 1.28.
```
