### PR TITLE
Enhance validation of `RsyslogRelpConfig`

### DIFF
--- a/pkg/apis/rsyslog/validation/rsyslog_relp.go
+++ b/pkg/apis/rsyslog/validation/rsyslog_relp.go
@@ -142,6 +142,9 @@ func validateLoggingRules(loggingRules []rsyslog.LoggingRule, fldPath *field.Pat
 func validateProgramNames(programNames []string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	for index, name := range programNames {
+		if name == "" {
+			allErrs = append(allErrs, field.Invalid(fldPath.Index(index), name, ".programNames can't contain empty program name"))
+		}
 		if invalidCharactersForProgramNameRegex.MatchString(name) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Index(index), name, ".programNames can't contain `[`, `:` or `/`"))
 		}

--- a/pkg/apis/rsyslog/validation/validation_test.go
+++ b/pkg/apis/rsyslog/validation/validation_test.go
@@ -163,6 +163,26 @@ var _ = Describe("Validation", func() {
 			Expect(errorList).To(matcher)
 		})
 
+		It("should not allow a logging rule with set programNames to have empty names", func() {
+			config := rsyslog.RsyslogRelpConfig{
+				Target:       relpTarget,
+				Port:         relpTargetPort,
+				LoggingRules: []rsyslog.LoggingRule{{ProgramNames: []string{""}, Severity: ptr.To(4)}},
+			}
+
+			matcher := ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("loggingRules.programNames[0]"),
+					"BadValue": Equal(""),
+					"Detail":   Equal(".programNames can't contain empty program name"),
+				})),
+			)
+
+			errorList := validation.ValidateRsyslogRelpConfig(&config, path)
+			Expect(errorList).To(matcher)
+		})
+
 		It("should not allow a logging rule with set programNames to have invalid characters in the names", func() {
 			config := rsyslog.RsyslogRelpConfig{
 				Target:       relpTarget,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
This PR introduces additional validation for the `RsyslogRelpConfig` by validating the `target` and `permittedPeer` values using `RFC 1123` specifications. It also includes the extra validation for `programNames` which should not contain  `[`, `:` or `/`.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
Here we need to fine-tune our limitations for the `target`
https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/blob/72b832a902fb6bbb527c7d1d9fe322e2725422b0/pkg/apis/rsyslog/validation/rsyslog_relp.go#L36-L38
since there aren't many limitations listed in the [rsyslog documentation](https://www.rsyslog.com/doc/configuration/modules/omrelp.html#target).
/cc @plkokanov @Kostov6 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
