### PR TITLE
Fix roles in `ScrapeConfig`s

### DIFF
--- a/pkg/controller/lifecycle/monitoring.go
+++ b/pkg/controller/lifecycle/monitoring.go
@@ -122,7 +122,7 @@ func deployMonitoringConfig(ctx context.Context, c client.Client, namespace stri
 			}},
 			KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
 				APIServer:  ptr.To("https://kube-apiserver"),
-				Role:       "endpoints",
+				Role:       "Endpoints",
 				Namespaces: &monitoringv1alpha1.NamespaceDiscovery{Names: []string{metav1.NamespaceSystem}},
 				Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},


### PR DESCRIPTION
Since https://github.com/prometheus-operator/prometheus-operator/releases/tag/pkg/apis/monitoring/v0.76.0 only camel case roles are valid (see prometheus-operator/prometheus-operator@38900ce#diff-95caef4dacf48c47bf56afc00c513822feba29a5d2f6354b75c97a25a353d52fL75-R77)

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Since [`github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring@v0.76.0`](https://github.com/prometheus-operator/prometheus-operator/releases/tag/pkg/apis/monitoring/v0.76.0) only camel case roles are valid in `ScrapeConfig`s of `monitoring.coreos.com/v1alpha1` ([ref](https://github.com/prometheus-operator/prometheus-operator/commit/38900ce#diff-95caef4dacf48c47bf56afc00c513822feba29a5d2f6354b75c97a25a353d52fL75-R77)).
The old lower-case-only roles which are quite common in Gardener components are not valid anymore.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/12401

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix casing of `role` in `ScrapeConfig`.
```
