### PR TITLE
Adapt rsyslog-relp config cleaner DaemonSet to revisionHistoryLimit=2

### DIFF
--- a/pkg/component/rsyslogrelpconfigcleaner/rsyslog_relp_config_cleaner.go
+++ b/pkg/component/rsyslogrelpconfigcleaner/rsyslog_relp_config_cleaner.go
@@ -96,6 +96,7 @@ func (r *rsyslogRelpConfigCleaner) computeResourcesData() (map[string][]byte, er
 			Labels:    getLabels(),
 		},
 		Spec: appsv1.DaemonSetSpec{
+			RevisionHistoryLimit: ptr.To(int32(2)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: getLabels(),
 			},

--- a/test/integration/controller/lifecycle/lifecycle_test.go
+++ b/test/integration/controller/lifecycle/lifecycle_test.go
@@ -44,6 +44,7 @@ var _ = Describe("Lifecycle controller tests", func() {
 				Namespace: "kube-system",
 			},
 			Spec: appsv1.DaemonSetSpec{
+				RevisionHistoryLimit: ptr.To(int32(2)),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"app.kubernetes.io/instance": "rsyslog-relp-configuration-cleaner",


### PR DESCRIPTION
**How to categorize this PR?**

/area security
/kind enhancement

**What this PR does / why we need it**:
The `rsyslog-relp-configuration-cleaner` DaemonSet did not set `RevisionHistoryLimit` and therefore defaulted to 10. This change sets it to 2 to align with the component checklist rule (now also covering DaemonSets, see gardener/gardener#13204).

**Which issue(s) this PR fixes**:
Part of gardener/gardener#13889

**Special notes for your reviewer**:
N/A

**Release note**:
```other operator
`rsyslog-relp-configuration-cleaner` DaemonSet now sets `revisionHistoryLimit` to 2 to comply with the gardener component checklist.
```