### PR TITLE
Replace provider-extensions setup with Gardener remote setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,16 +19,10 @@ IMAGE_TAG                   := $(EFFECTIVE_VERSION)
 LD_FLAGS                    := "-w $(shell EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) bash $(GARDENER_HACK_DIR)/get-build-ld-flags.sh k8s.io/component-base $(REPO_ROOT)/VERSION $(EXTENSION_PREFIX)-$(NAME))"
 PARALLEL_E2E_TESTS          := 3
 GARDENER_REPO_ROOT          ?= $(REPO_ROOT)/../gardener
-SEED_NAME                   := provider-extensions
-SEED_KUBECONFIG             := $(GARDENER_REPO_ROOT)/example/provider-extensions/seed/kubeconfig
 RUNTIME_KUBECONFIG          := $(GARDENER_REPO_ROOT)/dev-setup/kubeconfigs/runtime/kubeconfig
 VIRTUAL_KUBECONFIG          := $(GARDENER_REPO_ROOT)/dev-setup/kubeconfigs/virtual-garden/kubeconfig
 SHOOT_NAME                  ?= local
 SHOOT_NAMESPACE             ?= garden-local
-
-ifneq ($(SEED_NAME),provider-extensions)
-	SEED_KUBECONFIG := $(GARDENER_REPO_ROOT)/example/provider-extensions/seed/kubeconfig-$(SEED_NAME)
-endif
 
 ifndef ARTIFACTS
 	export ARTIFACTS=/tmp/artifacts
@@ -170,29 +164,21 @@ export SKAFFOLD_PUSH = true
 export SKAFFOLD_LABEL = skaffold.dev/run-id=extension-local
 
 extension-up: $(SKAFFOLD) $(HELM) $(KUBECTL) $(KIND)
-	@LD_FLAGS=$(LD_FLAGS) GARDENER_REPO_ROOT=$(GARDENER_REPO_ROOT) $(SKAFFOLD) run --kubeconfig=$(RUNTIME_KUBECONFIG)
+	@LD_FLAGS=$(LD_FLAGS) GARDENER_HACK_DIR=$(GARDENER_HACK_DIR) $(SKAFFOLD) run --kubeconfig=$(RUNTIME_KUBECONFIG)
 
 extension-dev: $(SKAFFOLD) $(HELM) $(KUBECTL) $(KIND)
-	@LD_FLAGS=$(LD_FLAGS) GARDENER_REPO_ROOT=$(GARDENER_REPO_ROOT) $(SKAFFOLD) dev --cleanup=false --trigger=manual --kubeconfig=$(RUNTIME_KUBECONFIG)
+	@LD_FLAGS=$(LD_FLAGS) GARDENER_HACK_DIR=$(GARDENER_HACK_DIR) $(SKAFFOLD) dev --cleanup=false --trigger=manual --kubeconfig=$(RUNTIME_KUBECONFIG)
 
 extension-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
-	$(SKAFFOLD) delete
-	@# The validating webhook is not part of the chart but it is created on admission Pod startup.
-	@# The approach with the owner Namespace ("--webhook-config-owner-namespace") cannot be used here as the extension is not managed via the operator in this setup.
-	@# Hence, we have to delete the webhook explicitly.
 	$(SKAFFOLD) delete --kubeconfig=$(RUNTIME_KUBECONFIG)
 
 remote-extension-up remote-extension-down: export SKAFFOLD_LABEL = skaffold.dev/run-id=extension-remote
 
 remote-extension-up: $(SKAFFOLD) $(HELM) $(KUBECTL) $(YQ)
-	@LD_FLAGS=$(LD_FLAGS) ./hack/remote-extension-up.sh --path-seed-kubeconfig $(SEED_KUBECONFIG)
+	@LD_FLAGS=$(LD_FLAGS) GARDENER_HACK_DIR=$(GARDENER_HACK_DIR) ./hack/remote-extension-up.sh --path-runtime-kubeconfig $(RUNTIME_KUBECONFIG)
 
 remote-extension-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
-	$(SKAFFOLD) delete -m admission,extension
-	@# The validating webhook is not part of the chart but it is created on admission Pod startup.
-	@# The approach with the owner Namespace ("--webhook-config-owner-namespace") cannot be used here as the extension is not managed via the operator in this setup.
-	@# Hence, we have to delete the webhook explicitly.
-	$(KUBECTL) delete validatingwebhookconfiguration gardener-extension-shoot-rsyslog-relp-admission --ignore-not-found
+	$(SKAFFOLD) delete -m operator -p remote --kubeconfig=$(RUNTIME_KUBECONFIG)
 
 configure-shoot: $(HELM) $(KUBECTL) $(YQ)
 	@./hack/configure-shoot.sh --shoot-name $(SHOOT_NAME) --shoot-namespace $(SHOOT_NAMESPACE) --echo-server-image "$(ECHO_SERVER_IMAGE):$(ECHO_SERVER_VERSION)"

--- a/README.md
+++ b/README.md
@@ -13,5 +13,6 @@ Gardener extension controller which configures the rsyslog and auditd services i
 ## Local Setup and Development
 
 * [Deploying the Rsyslog Relp Extension Locally](docs/development/getting-started.md) - learn how to set up a local development environment
+* [Deploying the Rsyslog Relp Extension in Gardener's Remote Setup](docs/development/getting-started-remotely.md) - learn how to set up a remote development environment using an existing Kubernetes cluster
 * [Developer Docs for Gardener Shoot Rsyslog Relp Extension](docs/development/shoot-rsyslog-relp.md) -  learn about the inner workings
 * [Validation Guidelines for Gardener Shoot Rsyslog Relp Extension](docs/development/input-validation.md) - learn about input validation specifics

--- a/dev-setup/remote/extension-patch.yaml
+++ b/dev-setup/remote/extension-patch.yaml
@@ -1,0 +1,22 @@
+apiVersion: operator.gardener.cloud/v1alpha1
+kind: Extension
+metadata:
+  name: extension-shoot-rsyslog-relp
+spec:
+  deployment:
+    extension:
+      helm:
+        ociRepository:
+          pullSecretRef:
+            name: gardener-images
+    admission:
+      runtimeCluster:
+        helm:
+          ociRepository:
+            pullSecretRef:
+              name: gardener-images
+      virtualCluster:
+        helm:
+          ociRepository:
+            pullSecretRef:
+              name: gardener-images

--- a/dev-setup/remote/kustomization.yaml
+++ b/dev-setup/remote/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../local
+
+patches:
+- path: extension-patch.yaml

--- a/docs/development/getting-started-remotely.md
+++ b/docs/development/getting-started-remotely.md
@@ -1,48 +1,39 @@
 ---
-title: Deploying Rsyslog Relp Extension Remotely
-description: Learn how to set up a development environment using own Seed clusters on an existing Kubernetes cluster
+title: Deploying Rsyslog Relp Extension in Gardener’s Remote Setup
+description: Learn how to set up a remote development environment using an existing Kubernetes cluster
 ---
 
-# Deploying Rsyslog Relp Extension Remotely
-
-This document will walk you through running the Rsyslog Relp extension controller on a remote seed cluster and the rsyslog relp admission component in your local garden cluster for development purposes. This guide uses Gardener's [setup with provider extensions](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally_with_extensions.md) and builds on top of it.
-
-If you encounter difficulties, please open an issue so that we can make this process easier.
+# Deploying Rsyslog Relp Extension in Gardener’s Remote Setup
 
 ## Prerequisites
 
-- Make sure that you have a running Gardener setup with provider extensions. The steps to complete this can be found in the [Deploying Gardener Locally and Enabling Provider-Extensions](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally_with_extensions.md) guide.
-- Make sure you are running Gardener version `>= 1.95.0` or the latest version of the master branch.
+- Make sure that you have a running Gardener remote setup. The steps to complete this can be found in the [Deploying Gardener Remotely](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_remotely.md) guide.
 
 > [!TIP]
 > Ensure that the locally used Gardener version matches the version specified by the `github.com/gardener/gardener` dependency.
-> The extension’s local setup must run successfully against a local Gardener setup at the version referenced by this dependency.
+> The extension’s remote setup must run successfully against a Gardener remote setup at the version referenced by this dependency.
+
+> [!NOTE]
+> The location of the Gardener project is expected to be under the same root (e.g. `~/go/src/github.com/gardener/`). If this is not the case, the location of Gardener project should be specified in `GARDENER_REPO_ROOT` environment variable:
+> ```bash
+> export GARDENER_REPO_ROOT="<path_to_gardener_project>"
+> ```
 
 ## Setting up the Rsyslog Relp Extension
 
-**Important:** Make sure that your `KUBECONFIG` env variable is targeting the local Gardener cluster!
-
-The location of the Gardener project from the Gardener setup is expected to be under the same root as this repository (e.g. ~/go/src/github.com/gardener/). If this is not the case, the location of Gardener project should be specified in `GARDENER_REPO_ROOT` environment variable:
-
 ```bash
-export GARDENER_REPO_ROOT="<path_to_gardener_project>"
-```
-
-Then you can run:
-
- ```bash
 make remote-extension-up
 ```
 
-In case you have added additional Seeds you can specify the seed name:
-
-```bash
-make remote-extension-up SEED_NAME=<seed-name>
-```
+The corresponding make target will build the `shoot-rsyslog-relp`, `shoot-rsyslog-relp-admission` container images, OCI artifacts for the admission runtime and application charts, and the extension chart. Then, the container images and the OCI artifacts are pushed into the container registry in the remote Gardener cluster.
+Next, the `shoot-rsyslog-relp` `Extension.operator.gardener.cloud` resource is deployed into the Gardener runtime cluster. Based on this resource the gardener-operator will deploy the `shoot-rsyslog-relp` admission component in the Gardener runtime cluster, as well as the `shoot-rsyslog-relp` ControllerDeployment and ControllerRegistration resources in the virtual Gardener cluster.
 
 ## Creating a Shoot Cluster
 
-Once the above step is completed, you can create a Shoot cluster. In order to create a Shoot cluster, please create your own `Shoot` definition depending on providers on your `Seed` cluster.
+> [!NOTE]
+> Make sure that your `KUBECONFIG` environment variable is targeting the virtual Garden cluster (i.e. `<path_to_gardener_project>/dev-setup/kubeconfigs/virtual-garden/kubeconfig`).
+
+Once the above step is completed, you can create a Shoot cluster. In order to create a Shoot cluster, please create your own Shoot definition depending on providers on your Seed cluster.
 
 ## Configuring the Shoot Cluster and deploying the Rsyslog Relp Echo Server
 
@@ -56,14 +47,12 @@ This command will deploy an rsyslog relp echo server in your Shoot cluster in th
 It will also add configuration for the `shoot-rsyslog-relp` extension to your `Shoot` spec by patching it with `./example/extension/<shoot-name>--<shoot-namespace>--extension-config-patch.yaml`. This file is automatically copied from `extension-config-patch.yaml.tmpl` in the same directory when you run `make configure-shoot` for the first time. The file also includes explanations of the properties you should set or change.
 The command will also deploy the `rsyslog-relp-tls` secret in case you wish to enable tls.
 
-
-
 ## Tearing Down the Development Environment
 
-To tear down the development environment, delete the Shoot cluster or disable the `shoot-rsyslog-relp` extension in the Shoot's specification. When the extension is not used by the Shoot anymore, you can run:
+To tear down the development environment, delete the Shoot cluster or disable the `shoot-rsyslog-relp` extension in the Shoot’s specification. When the extension is not used by the Shoot anymore, you can run:
 
 ```bash
 make remote-extension-down
 ```
 
-The make target will delete the ControllerDeployment and ControllerRegistration of the extension, and the `shoot-rsyslog-relp` admission helm deployment.
+The corresponding make target will delete the `Extension.operator.gardener.cloud` resource. Consequently, the gardener-operator will delete the `shoot-rsyslog-relp` admission component and `shoot-rsyslog-relp` ControllerDeployment and ControllerRegistration resources.

--- a/hack/remote-extension-up.sh
+++ b/hack/remote-extension-up.sh
@@ -7,13 +7,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-PATH_SEED_KUBECONFIG=""
+PATH_RUNTIME_KUBECONFIG=""
 
 parse_flags() {
   while test $# -gt 0; do
     case "$1" in
-    --path-seed-kubeconfig)
-      shift; PATH_SEED_KUBECONFIG="$1"
+    --path-runtime-kubeconfig)
+      shift; PATH_RUNTIME_KUBECONFIG="$1"
       ;;
     *)
       echo "Unknown argument: $1"
@@ -32,17 +32,14 @@ cleanup_shoot_info() {
 }
 trap cleanup_shoot_info EXIT
 
-if kubectl get configmaps -n kube-system shoot-info --kubeconfig "$PATH_SEED_KUBECONFIG" -o yaml > "$temp_shoot_info"; then
+if kubectl get configmaps -n kube-system shoot-info --kubeconfig "$PATH_RUNTIME_KUBECONFIG" -o yaml > "$temp_shoot_info"; then
     echo "Getting registry domain from shoot"
     registry_domain=reg.$(yq -e '.data.domain' "$temp_shoot_info")
 else
-  echo "Please enter domain name for registry on the seed"
+  echo "Please enter domain name for the registry domain on the runtime cluster"
   echo "Registry domain:"
   read -er registry_domain
 fi
-
-echo "Deploying shoot-rsyslog-relp admission in garden cluster"
-skaffold run -m admission -p remote-extension
 
 echo "Deploying shoot-rsyslog-relp extension"
 SKAFFOLD_DEFAULT_REPO=$registry_domain \
@@ -50,4 +47,4 @@ SKAFFOLD_CHECK_CLUSTER_NODE_PLATFORMS="false" \
 SKAFFOLD_PLATFORM="linux/amd64" \
 SKAFFOLD_DISABLE_MULTI_PLATFORM_BUILD="false" \
   SKAFFOLD_PUSH=true \
-  skaffold run -m extension
+  skaffold run -m operator -p remote --kubeconfig "$PATH_RUNTIME_KUBECONFIG"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -7,9 +7,6 @@ build:
     - registry.local.gardener.cloud:5001
   artifacts:
     - image: local-skaffold/gardener-extension-shoot-rsyslog-relp-echo-server
-      docker:
-        cacheFrom:
-          - local-skaffold/gardener-extension-shoot-rsyslog-relp-echo-server
   local: {}
 deploy:
   helm:
@@ -80,14 +77,14 @@ build:
     - image: local-skaffold/gardener-extension-shoot-rsyslog-relp-admission/charts/application
       custom:
         buildCommand: |
-          bash "$GARDENER_REPO_ROOT/hack/push-helm.sh" ./charts/gardener-extension-shoot-rsyslog-relp-admission/charts/application .image.ref
+          bash "$GARDENER_HACK_DIR/push-helm.sh" ./charts/gardener-extension-shoot-rsyslog-relp-admission/charts/application .image.ref
         dependencies:
           paths:
             - charts/gardener-extension-shoot-rsyslog-relp-admission/charts/application
     - image: local-skaffold/gardener-extension-shoot-rsyslog-relp-admission/charts/runtime
       custom:
         buildCommand: |
-          bash "$GARDENER_REPO_ROOT/hack/push-helm.sh" ./charts/gardener-extension-shoot-rsyslog-relp-admission/charts/runtime .image.ref
+          bash "$GARDENER_HACK_DIR/push-helm.sh" ./charts/gardener-extension-shoot-rsyslog-relp-admission/charts/runtime .image.ref
         dependencies:
           paths:
             - charts/gardener-extension-shoot-rsyslog-relp-admission/charts/runtime
@@ -97,7 +94,7 @@ build:
     - image: local-skaffold/gardener-extension-shoot-rsyslog-relp/charts/extension
       custom:
         buildCommand: |
-          bash "$GARDENER_REPO_ROOT/hack/push-helm.sh" ./charts/gardener-extension-shoot-rsyslog-relp .image.ref
+          bash "$GARDENER_HACK_DIR/push-helm.sh" ./charts/gardener-extension-shoot-rsyslog-relp .image.ref
         dependencies:
           paths:
             - charts/gardener-extension-shoot-rsyslog-relp
@@ -119,3 +116,9 @@ resourceSelector:
         - .spec.deployment.extension.helm.ociRepository.ref
         - .spec.deployment.admission.runtimeCluster.helm.ociRepository.ref
         - .spec.deployment.admission.virtualCluster.helm.ociRepository.ref
+profiles:
+  - name: remote
+    manifests:
+      kustomize:
+        paths:
+          - dev-setup/remote


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind task

**What this PR does / why we need it**:
Adapt the `remote-extension-up` and `remote-extension-down` make targets to use the [Deploying Gardener Remotely](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_remotely.md) setup.

I also replaced usages of `GARDENER_REPO_ROOT` with `GARDENER_HACK_DIR` in the `skaffold.yaml` file because using the hack directory from the go mod dependency is more correct.

**Which issue(s) this PR fixes**:
Fixes #404

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
