### PR TITLE
Replace `k8s.io/utils/ptr.To` calls with `new`

### DIFF
--- a/.golangci.yaml.in
+++ b/.golangci.yaml.in
@@ -3,6 +3,7 @@ run:
   concurrency: 4
 linters:
   enable:
+    - forbidigo
     - ginkgolinter
     - importas
     - logcheck
@@ -13,6 +14,10 @@ linters:
     - unparam
     - whitespace
   settings:
+    forbidigo:
+      forbid:
+        - pattern: ^ptr\.To$
+          msg: "ptr.To shall no longer be used, please use the built-in new(T) instead. See https://github.com/gardener/gardener/pull/14872."
     loggercheck:
       require-string-key: true
       no-printf-like: true

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -65,7 +64,7 @@ var _ = Describe("Shoot", func() {
 		})
 
 		It("should not do anything because extension is disabled", func() {
-			shoot.Spec.Extensions[0].Disabled = ptr.To(true)
+			shoot.Spec.Extensions[0].Disabled = new(true)
 			Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 		})
 
@@ -269,7 +268,7 @@ tls:
 								Name:      "rsyslog-secret",
 								Namespace: "bar",
 							},
-							Immutable: ptr.To(true),
+							Immutable: new(true),
 							Data: map[string][]byte{
 								"ca":  []byte("data"),
 								"crt": []byte("data"),
@@ -385,7 +384,7 @@ auditConfig:
 					},
 					Entry(
 						"should return error when referenced configmap is mutable",
-						ptr.To(""), "", false,
+						new(""), "", false,
 						MatchError(ContainSubstring("configMap bar/audit-configmap must be immutable")),
 					),
 					Entry(
@@ -395,17 +394,17 @@ auditConfig:
 					),
 					Entry(
 						"should return error if referenced configMap has no data in 'data.auditd'",
-						ptr.To(""), "", true,
+						new(""), "", true,
 						MatchError(ContainSubstring("empty auditd config. Provide non-empty auditd config in configMap bar/audit-configmap")),
 					),
 					Entry(
 						"should return error if referenced configMap contains invalid config",
-						ptr.To("some policy"), "", true,
+						new("some policy"), "", true,
 						MatchError(ContainSubstring("could not decode 'data.auditd' field of configMap bar/audit-configmap")),
 					),
 					Entry(
 						"should return error if referenced configMap contains config with invalid kind",
-						ptr.To(`apiVersion: rsyslog-relp.extensions.gardener.cloud/v1alpha1
+						new(`apiVersion: rsyslog-relp.extensions.gardener.cloud/v1alpha1
 kind: Foo`), "",
 						true,
 						MatchError(runtime.NewNotRegisteredErrForKind(
@@ -419,7 +418,7 @@ kind: Foo`), "",
 					),
 					Entry(
 						"should return error if referenced configMap contains invalid auditd config",
-						ptr.To(`apiVersion: rsyslog-relp.extensions.gardener.cloud/v1alpha1
+						new(`apiVersion: rsyslog-relp.extensions.gardener.cloud/v1alpha1
 kind: Auditd`), "",
 						true,
 						ConsistOf(
@@ -432,7 +431,7 @@ kind: Auditd`), "",
 					),
 					Entry(
 						"should return error if configmap contains extra data",
-						ptr.To(`apiVersion: rsyslog-relp.extensions.gardener.cloud/v1alpha1
+						new(`apiVersion: rsyslog-relp.extensions.gardener.cloud/v1alpha1
 kind: Auditd
 auditRules: -a exit,always -F arch=b64 -S setuid -S setreuid -S setgid -S setregid -F auid>0 -F auid!=-1 -F key=privilege_escalation`), "foo",
 						true,
@@ -440,7 +439,7 @@ auditRules: -a exit,always -F arch=b64 -S setuid -S setreuid -S setgid -S setreg
 					),
 					Entry(
 						"should succeed",
-						ptr.To(`apiVersion: rsyslog-relp.extensions.gardener.cloud/v1alpha1
+						new(`apiVersion: rsyslog-relp.extensions.gardener.cloud/v1alpha1
 kind: Auditd
 auditRules: -a exit,always -F arch=b64 -S setuid -S setreuid -S setgid -S setregid -F auid>0 -F auid!=-1 -F key=privilege_escalation`), "",
 						true,

--- a/pkg/apis/rsyslog/validation/validation_test.go
+++ b/pkg/apis/rsyslog/validation/validation_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 	gomegatypes "github.com/onsi/gomega/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener-extension-shoot-rsyslog-relp/pkg/apis/rsyslog"
 	"github.com/gardener/gardener-extension-shoot-rsyslog-relp/pkg/apis/rsyslog/validation"
@@ -37,7 +36,7 @@ var _ = Describe("Validation", func() {
 			loggingRules = []rsyslog.LoggingRule{
 				{
 					ProgramNames: []string{"kubelet"},
-					Severity:     ptr.To(0),
+					Severity:     new(0),
 				},
 			}
 		)
@@ -167,7 +166,7 @@ var _ = Describe("Validation", func() {
 			config := rsyslog.RsyslogRelpConfig{
 				Target:       relpTarget,
 				Port:         relpTargetPort,
-				LoggingRules: []rsyslog.LoggingRule{{ProgramNames: []string{""}, Severity: ptr.To(4)}},
+				LoggingRules: []rsyslog.LoggingRule{{ProgramNames: []string{""}, Severity: new(4)}},
 			}
 
 			matcher := ConsistOf(
@@ -187,7 +186,7 @@ var _ = Describe("Validation", func() {
 			config := rsyslog.RsyslogRelpConfig{
 				Target:       relpTarget,
 				Port:         relpTargetPort,
-				LoggingRules: []rsyslog.LoggingRule{{ProgramNames: []string{"kube[let", ":kubelet", "kubelet/kubelet"}, Severity: ptr.To(4)}},
+				LoggingRules: []rsyslog.LoggingRule{{ProgramNames: []string{"kube[let", ":kubelet", "kubelet/kubelet"}, Severity: new(4)}},
 			}
 
 			matcher := ConsistOf(
@@ -219,7 +218,7 @@ var _ = Describe("Validation", func() {
 			config := rsyslog.RsyslogRelpConfig{
 				Target:       relpTarget,
 				Port:         relpTargetPort,
-				LoggingRules: []rsyslog.LoggingRule{{ProgramNames: []string{"kube let"}, Severity: ptr.To(4)}},
+				LoggingRules: []rsyslog.LoggingRule{{ProgramNames: []string{"kube let"}, Severity: new(4)}},
 			}
 
 			matcher := ConsistOf(
@@ -240,7 +239,7 @@ var _ = Describe("Validation", func() {
 				Target: relpTarget,
 				Port:   relpTargetPort,
 				LoggingRules: []rsyslog.LoggingRule{
-					{}, {ProgramNames: []string{"kubelet"}, Severity: ptr.To(4)},
+					{}, {ProgramNames: []string{"kubelet"}, Severity: new(4)},
 				},
 			}
 
@@ -262,7 +261,7 @@ var _ = Describe("Validation", func() {
 				Target: relpTarget,
 				Port:   relpTargetPort,
 				LoggingRules: []rsyslog.LoggingRule{
-					{ProgramNames: []string{"kubelet"}, Severity: ptr.To(4)},
+					{ProgramNames: []string{"kubelet"}, Severity: new(4)},
 					{MessageContent: &rsyslog.MessageContent{}},
 				},
 			}
@@ -285,8 +284,8 @@ var _ = Describe("Validation", func() {
 				Target: relpTarget,
 				Port:   relpTargetPort,
 				LoggingRules: []rsyslog.LoggingRule{
-					{MessageContent: &rsyslog.MessageContent{Regex: ptr.To("(match")}},
-					{MessageContent: &rsyslog.MessageContent{Exclude: ptr.To("(match")}},
+					{MessageContent: &rsyslog.MessageContent{Regex: new("(match")}},
+					{MessageContent: &rsyslog.MessageContent{Exclude: new("(match")}},
 				},
 			}
 
@@ -317,7 +316,7 @@ var _ = Describe("Validation", func() {
 				},
 
 				Entry("should allow config when all setting are correct",
-					rsyslog.RsyslogRelpConfig{Target: relpTarget, Port: relpTargetPort, TLS: &rsyslog.TLS{Enabled: true, SecretReferenceName: ptr.To("secretRef"), PermittedPeer: []string{"per"}, AuthMode: &authModeName}, LoggingRules: loggingRules, RebindInterval: ptr.To(1000), Timeout: ptr.To(90), ResumeRetryCount: ptr.To(10), ReportSuspensionContinuation: ptr.To(true)},
+					rsyslog.RsyslogRelpConfig{Target: relpTarget, Port: relpTargetPort, TLS: &rsyslog.TLS{Enabled: true, SecretReferenceName: new("secretRef"), PermittedPeer: []string{"per"}, AuthMode: &authModeName}, LoggingRules: loggingRules, RebindInterval: new(1000), Timeout: new(90), ResumeRetryCount: new(10), ReportSuspensionContinuation: new(true)},
 					BeEmpty(),
 				),
 			)
@@ -340,7 +339,7 @@ var _ = Describe("Validation", func() {
 				),
 
 				Entry("should allow config when TLS is enabled and secretReferenceName is set",
-					rsyslog.TLS{Enabled: true, SecretReferenceName: ptr.To("secret-name")},
+					rsyslog.TLS{Enabled: true, SecretReferenceName: new("secret-name")},
 					BeEmpty(),
 				),
 
@@ -357,17 +356,17 @@ var _ = Describe("Validation", func() {
 				),
 
 				Entry("should allow config when TLS authMode is name",
-					rsyslog.TLS{Enabled: true, SecretReferenceName: ptr.To("secret-name"), AuthMode: &authModeName},
+					rsyslog.TLS{Enabled: true, SecretReferenceName: new("secret-name"), AuthMode: &authModeName},
 					BeEmpty(),
 				),
 
 				Entry("should allow config when TLS authMode is fingerprint",
-					rsyslog.TLS{Enabled: true, SecretReferenceName: ptr.To("secret-name"), AuthMode: &authModeFingerPrint},
+					rsyslog.TLS{Enabled: true, SecretReferenceName: new("secret-name"), AuthMode: &authModeFingerPrint},
 					BeEmpty(),
 				),
 
 				Entry("should forbid config when TLS authMode is invalid",
-					rsyslog.TLS{Enabled: true, SecretReferenceName: ptr.To("secret-name"), AuthMode: &authModeInvalid},
+					rsyslog.TLS{Enabled: true, SecretReferenceName: new("secret-name"), AuthMode: &authModeInvalid},
 					ConsistOf(
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":     Equal(field.ErrorTypeNotSupported),
@@ -379,17 +378,17 @@ var _ = Describe("Validation", func() {
 				),
 
 				Entry("should allow config when tls lib is openssl",
-					rsyslog.TLS{Enabled: true, SecretReferenceName: ptr.To("secret-name"), TLSLib: &tlsLibOpenSSL},
+					rsyslog.TLS{Enabled: true, SecretReferenceName: new("secret-name"), TLSLib: &tlsLibOpenSSL},
 					BeEmpty(),
 				),
 
 				Entry("should allow config when tls lib is gnutls",
-					rsyslog.TLS{Enabled: true, SecretReferenceName: ptr.To("secret-name"), TLSLib: &tlsLibGnuTLS},
+					rsyslog.TLS{Enabled: true, SecretReferenceName: new("secret-name"), TLSLib: &tlsLibGnuTLS},
 					BeEmpty(),
 				),
 
 				Entry("should forbid config when tls lib is invalid",
-					rsyslog.TLS{Enabled: true, SecretReferenceName: ptr.To("secret-name"), TLSLib: &tlsLibInvalid},
+					rsyslog.TLS{Enabled: true, SecretReferenceName: new("secret-name"), TLSLib: &tlsLibInvalid},
 					ConsistOf(
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":     Equal(field.ErrorTypeNotSupported),
@@ -401,12 +400,12 @@ var _ = Describe("Validation", func() {
 				),
 
 				Entry("should allow config when permittedPeer is specified",
-					rsyslog.TLS{Enabled: true, SecretReferenceName: ptr.To("secret-name"), PermittedPeer: []string{"peer1", "peer2"}},
+					rsyslog.TLS{Enabled: true, SecretReferenceName: new("secret-name"), PermittedPeer: []string{"peer1", "peer2"}},
 					BeEmpty(),
 				),
 
 				Entry("should forbid config if any permittedPeer is empty",
-					rsyslog.TLS{Enabled: true, SecretReferenceName: ptr.To("secret-name"), PermittedPeer: []string{"peer1", ""}},
+					rsyslog.TLS{Enabled: true, SecretReferenceName: new("secret-name"), PermittedPeer: []string{"peer1", ""}},
 					ConsistOf(
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":     Equal(field.ErrorTypeRequired),
@@ -418,7 +417,7 @@ var _ = Describe("Validation", func() {
 				),
 
 				Entry("should forbid config if any permittedPeer isn't an allowed value",
-					rsyslog.TLS{Enabled: true, SecretReferenceName: ptr.To("secret-name"), PermittedPeer: []string{"peer1", "SHA1:zzz", "*.*.bar.com"}},
+					rsyslog.TLS{Enabled: true, SecretReferenceName: new("secret-name"), PermittedPeer: []string{"peer1", "SHA1:zzz", "*.*.bar.com"}},
 					ConsistOf(
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":     Equal(field.ErrorTypeInvalid),

--- a/pkg/component/rsyslogrelpconfigcleaner/rsyslog_relp_config_cleaner.go
+++ b/pkg/component/rsyslogrelpconfigcleaner/rsyslog_relp_config_cleaner.go
@@ -16,7 +16,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener-extension-shoot-rsyslog-relp/pkg/constants"
@@ -96,7 +95,7 @@ func (r *rsyslogRelpConfigCleaner) computeResourcesData() (map[string][]byte, er
 			Labels:    getLabels(),
 		},
 		Spec: appsv1.DaemonSetSpec{
-			RevisionHistoryLimit: ptr.To(int32(2)),
+			RevisionHistoryLimit: new(int32(2)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: getLabels(),
 			},
@@ -105,7 +104,7 @@ func (r *rsyslogRelpConfigCleaner) computeResourcesData() (map[string][]byte, er
 					Labels: getLabels(),
 				},
 				Spec: corev1.PodSpec{
-					AutomountServiceAccountToken: ptr.To(false),
+					AutomountServiceAccountToken: new(false),
 					PriorityClassName:            v1beta1constants.PriorityClassNameShootSystem700,
 					SecurityContext: &corev1.PodSecurityContext{
 						SeccompProfile: &corev1.SeccompProfile{
@@ -119,7 +118,7 @@ func (r *rsyslogRelpConfigCleaner) computeResourcesData() (map[string][]byte, er
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Command:         computeCommand(),
 							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: ptr.To(false),
+								AllowPrivilegeEscalation: new(false),
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
@@ -145,7 +144,7 @@ func (r *rsyslogRelpConfigCleaner) computeResourcesData() (map[string][]byte, er
 							Image:           r.values.PauseContainerImage,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: ptr.To(false),
+								AllowPrivilegeEscalation: new(false),
 							},
 						},
 					},

--- a/pkg/controller/lifecycle/monitoring.go
+++ b/pkg/controller/lifecycle/monitoring.go
@@ -16,7 +16,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener-extension-shoot-rsyslog-relp/pkg/apis/rsyslog"
@@ -44,7 +43,7 @@ func deployMonitoringConfig(ctx context.Context, c client.Client, namespace stri
 		{
 			Alert: "RsyslogTooManyRelpActionFailures",
 			Expr:  intstr.FromString(`sum(rate(rsyslog_pstat_failed{origin="core.action",name="rsyslg-relp"}[5m])) / sum(rate(rsyslog_pstat_processed{origin="core.action",name="rsyslog-relp"}[5m])) > bool 0.02 == 1`),
-			For:   ptr.To(monitoringv1.Duration("15m")),
+			For:   new(monitoringv1.Duration("15m")),
 			Labels: map[string]string{
 				"service":    "rsyslog-relp",
 				"severity":   "warning",
@@ -59,7 +58,7 @@ func deployMonitoringConfig(ctx context.Context, c client.Client, namespace stri
 		{
 			Alert: "RsyslogRelpActionProcessingRateIsZero",
 			Expr:  intstr.FromString(`rate(rsyslog_pstat_processed{origin="core.action",name="rsyslog-relp"}[5m]) == 0`),
-			For:   ptr.To(monitoringv1.Duration("15m")),
+			For:   new(monitoringv1.Duration("15m")),
 			Labels: map[string]string{
 				"service":    "rsyslog-relp",
 				"severity":   "warning",
@@ -77,7 +76,7 @@ func deployMonitoringConfig(ctx context.Context, c client.Client, namespace stri
 		alertingRules = append(alertingRules, monitoringv1.Rule{
 			Alert: "RsyslogRelpAuditRulesNotLoadedSuccessfully",
 			Expr:  intstr.FromString(`absent(rsyslog_augenrules_load_success == 1)`),
-			For:   ptr.To(monitoringv1.Duration("15m")),
+			For:   new(monitoringv1.Duration("15m")),
 			Labels: map[string]string{
 				"service":    "rsyslog-relp",
 				"severity":   "warning",
@@ -111,17 +110,17 @@ func deployMonitoringConfig(ctx context.Context, c client.Client, namespace stri
 		metav1.SetMetaDataLabel(&scrapeConfig.ObjectMeta, "component", constants.ServiceName)
 		metav1.SetMetaDataLabel(&scrapeConfig.ObjectMeta, "prometheus", "shoot")
 		scrapeConfig.Spec = monitoringv1alpha1.ScrapeConfigSpec{
-			HonorLabels:   ptr.To(false),
-			ScrapeTimeout: ptr.To(monitoringv1.Duration("30s")),
-			Scheme:        ptr.To(monitoringv1.SchemeHTTPS),
+			HonorLabels:   new(false),
+			ScrapeTimeout: new(monitoringv1.Duration("30s")),
+			Scheme:        new(monitoringv1.SchemeHTTPS),
 			// This is needed because the kubelets' certificates are not are generated for a specific pod IP
-			TLSConfig: &monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)},
+			TLSConfig: &monitoringv1.SafeTLSConfig{InsecureSkipVerify: new(true)},
 			Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
 				Key:                  "token",
 			}},
 			KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
-				APIServer:  ptr.To("https://kube-apiserver"),
+				APIServer:  new("https://kube-apiserver"),
 				Role:       "Endpoints",
 				Namespaces: &monitoringv1alpha1.NamespaceDiscovery{Names: []string{metav1.NamespaceSystem}},
 				Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
@@ -129,18 +128,18 @@ func deployMonitoringConfig(ctx context.Context, c client.Client, namespace stri
 					Key:                  "token",
 				}},
 				// This is needed because we do not fetch the correct cluster CA bundle right now
-				TLSConfig:       &monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)},
-				FollowRedirects: ptr.To(true),
+				TLSConfig:       &monitoringv1.SafeTLSConfig{InsecureSkipVerify: new(true)},
+				FollowRedirects: new(true),
 			}},
 			RelabelConfigs: []monitoringv1.RelabelConfig{
 				{
 					Action:      "replace",
-					Replacement: ptr.To("rsyslog-metrics"),
+					Replacement: new("rsyslog-metrics"),
 					TargetLabel: "job",
 				},
 				{
 					TargetLabel: "type",
-					Replacement: ptr.To("shoot"),
+					Replacement: new("shoot"),
 				},
 				{
 					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_name", "__meta_kubernetes_endpoint_port_name"},
@@ -161,13 +160,13 @@ func deployMonitoringConfig(ctx context.Context, c client.Client, namespace stri
 				},
 				{
 					TargetLabel: "__address__",
-					Replacement: ptr.To("kube-apiserver:443"),
+					Replacement: new("kube-apiserver:443"),
 				},
 				{
 					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_name", "__meta_kubernetes_pod_container_port_number"},
 					Regex:        `(.+);(.+)`,
 					TargetLabel:  "__metrics_path__",
-					Replacement:  ptr.To("/api/v1/namespaces/kube-system/pods/${1}:${2}/proxy/metrics"),
+					Replacement:  new("/api/v1/namespaces/kube-system/pods/${1}:${2}/proxy/metrics"),
 				},
 			},
 			MetricRelabelConfigs: monitoringutils.StandardMetricRelabelConfig("rsyslog_.+"),

--- a/pkg/webhook/operatingsystemconfig/auditd.go
+++ b/pkg/webhook/operatingsystemconfig/auditd.go
@@ -17,7 +17,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener-extension-shoot-rsyslog-relp/pkg/apis/rsyslog"
@@ -79,7 +78,7 @@ func getAuditConfigFromConfigMap(ctx context.Context, c client.Client, decoder r
 
 	return []extensionsv1alpha1.File{{
 		Path:        fmt.Sprintf("%s/%s", constants.AuditRulesFromOSCDir, "00_shoot_rsyslog_relp.rules"),
-		Permissions: ptr.To(uint32(0644)),
+		Permissions: new(uint32(0644)),
 		Content: extensionsv1alpha1.FileContent{
 			Inline: &extensionsv1alpha1.FileContentInline{
 				Encoding: "b64",
@@ -93,7 +92,7 @@ func getDefaultAuditRules() []extensionsv1alpha1.File {
 	return []extensionsv1alpha1.File{
 		{
 			Path:        baseConfigRulesPath,
-			Permissions: ptr.To(uint32(0744)),
+			Permissions: new(uint32(0744)),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
 					Encoding: "b64",
@@ -103,7 +102,7 @@ func getDefaultAuditRules() []extensionsv1alpha1.File {
 		},
 		{
 			Path:        privilegeEscalationRulesPath,
-			Permissions: ptr.To(uint32(0744)),
+			Permissions: new(uint32(0744)),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
 					Encoding: "b64",
@@ -113,7 +112,7 @@ func getDefaultAuditRules() []extensionsv1alpha1.File {
 		},
 		{
 			Path:        privilegeSpecialRulesPath,
-			Permissions: ptr.To(uint32(0744)),
+			Permissions: new(uint32(0744)),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
 					Encoding: "b64",
@@ -123,7 +122,7 @@ func getDefaultAuditRules() []extensionsv1alpha1.File {
 		},
 		{
 			Path:        systemIntegrityRulesPath,
-			Permissions: ptr.To(uint32(0744)),
+			Permissions: new(uint32(0744)),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
 					Encoding: "b64",

--- a/pkg/webhook/operatingsystemconfig/ensurer_test.go
+++ b/pkg/webhook/operatingsystemconfig/ensurer_test.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -86,19 +85,19 @@ var _ = Describe("Ensurer", func() {
 			Port:   10250,
 			LoggingRules: []rsyslog.LoggingRule{
 				{
-					Severity:     ptr.To(5),
+					Severity:     new(5),
 					ProgramNames: []string{"systemd", "audisp-syslog"},
 					MessageContent: &rsyslog.MessageContent{
-						Regex:   ptr.To("foo"),
-						Exclude: ptr.To("bar"),
+						Regex:   new("foo"),
+						Exclude: new("bar"),
 					},
 				},
 				{
-					Severity:     ptr.To(7),
+					Severity:     new(7),
 					ProgramNames: []string{"kubelet"},
 				},
 				{
-					Severity: ptr.To(2),
+					Severity: new(2),
 				},
 			},
 			AuditConfig: &rsyslog.AuditConfig{
@@ -196,7 +195,7 @@ var _ = Describe("Ensurer", func() {
 
 				extensionProviderConfig.TLS = &rsyslog.TLS{
 					Enabled:             true,
-					SecretReferenceName: ptr.To("rsyslog-tls"),
+					SecretReferenceName: new("rsyslog-tls"),
 					AuthMode:            &authModeName,
 					TLSLib:              &tlsLibOpenSSL,
 					PermittedPeer:       []string{"rsyslog-server.foo", "rsyslog-server.foo.bar"},
@@ -249,14 +248,14 @@ auditRules: |
 
 				extensionProviderConfig.AuditConfig = &rsyslog.AuditConfig{
 					Enabled:                true,
-					ConfigMapReferenceName: ptr.To("audit-rules"),
+					ConfigMapReferenceName: new("audit-rules"),
 				}
 
 				expectedFiles = append([]extensionsv1alpha1.File{oldFile}, webhooktest.GetRsyslogFiles(webhooktest.GetTestingRsyslogConfig(), true)...)
 				expectedFiles = append(expectedFiles, []extensionsv1alpha1.File{
 					{
 						Path:        "/var/lib/rsyslog-relp-configurator/audit/rules.d/00_shoot_rsyslog_relp.rules",
-						Permissions: ptr.To(uint32(0644)),
+						Permissions: new(uint32(0644)),
 						Content: extensionsv1alpha1.FileContent{
 							Inline: &extensionsv1alpha1.FileContentInline{
 								Encoding: "b64",

--- a/pkg/webhook/operatingsystemconfig/rsyslog.go
+++ b/pkg/webhook/operatingsystemconfig/rsyslog.go
@@ -18,7 +18,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils"
-	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener-extension-shoot-rsyslog-relp/pkg/apis/rsyslog"
 	"github.com/gardener/gardener-extension-shoot-rsyslog-relp/pkg/constants"
@@ -115,7 +114,7 @@ func getRsyslogFiles(rsyslogRelpConfig *rsyslog.RsyslogRelpConfig, cluster *exte
 	rsyslogFiles = append(rsyslogFiles, []extensionsv1alpha1.File{
 		{
 			Path:        constants.RsyslogConfigFromOSCPath,
-			Permissions: ptr.To(uint32(0744)),
+			Permissions: new(uint32(0744)),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
 					Encoding: "b64",
@@ -125,7 +124,7 @@ func getRsyslogFiles(rsyslogRelpConfig *rsyslog.RsyslogRelpConfig, cluster *exte
 		},
 		{
 			Path:        constants.ConfigureRsyslogScriptPath,
-			Permissions: ptr.To(uint32(0744)),
+			Permissions: new(uint32(0744)),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
 					Encoding: "b64",
@@ -135,7 +134,7 @@ func getRsyslogFiles(rsyslogRelpConfig *rsyslog.RsyslogRelpConfig, cluster *exte
 		},
 		{
 			Path:        constants.ProcessRsyslogPstatsScriptPath,
-			Permissions: ptr.To(uint32(0744)),
+			Permissions: new(uint32(0744)),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
 					Encoding: "b64",
@@ -145,7 +144,7 @@ func getRsyslogFiles(rsyslogRelpConfig *rsyslog.RsyslogRelpConfig, cluster *exte
 		},
 		{
 			Path:        rsyslogServiceMemoryLimitsDropInPath,
-			Permissions: ptr.To(uint32(0644)),
+			Permissions: new(uint32(0644)),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
 					Data: `[Service]
@@ -167,9 +166,9 @@ func getRsyslogValues(rsyslogRelpConfig *rsyslog.RsyslogRelpConfig, cluster *ext
 	var reportSuspensionContinuation *string
 	if rsyslogRelpConfig.ReportSuspensionContinuation != nil {
 		if *rsyslogRelpConfig.ReportSuspensionContinuation {
-			reportSuspensionContinuation = ptr.To("on")
+			reportSuspensionContinuation = new("on")
 		} else {
-			reportSuspensionContinuation = ptr.To("off")
+			reportSuspensionContinuation = new("off")
 		}
 	}
 
@@ -227,7 +226,7 @@ func getRsyslogTLSFiles(cluster *extensionscontroller.Cluster, secretRefName str
 	return []extensionsv1alpha1.File{
 		{
 			Path:        constants.RsyslogTLSFromOSCDir + "/ca.crt",
-			Permissions: ptr.To(uint32(0600)),
+			Permissions: new(uint32(0600)),
 			Content: extensionsv1alpha1.FileContent{
 				SecretRef: &extensionsv1alpha1.FileContentSecretRef{
 					Name:    refSecretName,
@@ -237,7 +236,7 @@ func getRsyslogTLSFiles(cluster *extensionscontroller.Cluster, secretRefName str
 		},
 		{
 			Path:        constants.RsyslogTLSFromOSCDir + "/tls.crt",
-			Permissions: ptr.To(uint32(0600)),
+			Permissions: new(uint32(0600)),
 			Content: extensionsv1alpha1.FileContent{
 				SecretRef: &extensionsv1alpha1.FileContentSecretRef{
 					Name:    refSecretName,
@@ -247,7 +246,7 @@ func getRsyslogTLSFiles(cluster *extensionscontroller.Cluster, secretRefName str
 		},
 		{
 			Path:        constants.RsyslogTLSFromOSCDir + "/tls.key",
-			Permissions: ptr.To(uint32(0600)),
+			Permissions: new(uint32(0600)),
 			Content: extensionsv1alpha1.FileContent{
 				SecretRef: &extensionsv1alpha1.FileContentSecretRef{
 					Name:    refSecretName,
@@ -261,9 +260,9 @@ func getRsyslogTLSFiles(cluster *extensionscontroller.Cluster, secretRefName str
 func getRsyslogConfiguratorUnit() extensionsv1alpha1.Unit {
 	return extensionsv1alpha1.Unit{
 		Name:    "rsyslog-configurator.service",
-		Command: ptr.To(extensionsv1alpha1.CommandStart),
-		Enable:  ptr.To(true),
-		Content: ptr.To(`[Unit]
+		Command: new(extensionsv1alpha1.CommandStart),
+		Enable:  new(true),
+		Content: new(`[Unit]
 Description=rsyslog configurator daemon
 Documentation=https://github.com/gardener/gardener-extension-shoot-rsyslog-relp
 [Service]

--- a/pkg/webhook/operatingsystemconfig/webhooktest/webhooktest.go
+++ b/pkg/webhook/operatingsystemconfig/webhooktest/webhooktest.go
@@ -10,7 +10,6 @@ import (
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils"
-	"k8s.io/utils/ptr"
 )
 
 var (
@@ -41,7 +40,7 @@ func GetAuditRulesFiles(useExpectedContent bool) []extensionsv1alpha1.File {
 	return []extensionsv1alpha1.File{
 		{
 			Path:        "/var/lib/rsyslog-relp-configurator/audit/rules.d/00-base-config.rules",
-			Permissions: ptr.To(uint32(0744)),
+			Permissions: new(uint32(0744)),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
 					Encoding: "b64",
@@ -51,7 +50,7 @@ func GetAuditRulesFiles(useExpectedContent bool) []extensionsv1alpha1.File {
 		},
 		{
 			Path:        "/var/lib/rsyslog-relp-configurator/audit/rules.d/10-privilege-escalation.rules",
-			Permissions: ptr.To(uint32(0744)),
+			Permissions: new(uint32(0744)),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
 					Encoding: "b64",
@@ -61,7 +60,7 @@ func GetAuditRulesFiles(useExpectedContent bool) []extensionsv1alpha1.File {
 		},
 		{
 			Path:        "/var/lib/rsyslog-relp-configurator/audit/rules.d/11-privileged-special.rules",
-			Permissions: ptr.To(uint32(0744)),
+			Permissions: new(uint32(0744)),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
 					Encoding: "b64",
@@ -71,7 +70,7 @@ func GetAuditRulesFiles(useExpectedContent bool) []extensionsv1alpha1.File {
 		},
 		{
 			Path:        "/var/lib/rsyslog-relp-configurator/audit/rules.d/12-system-integrity.rules",
-			Permissions: ptr.To(uint32(0744)),
+			Permissions: new(uint32(0744)),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
 					Encoding: "b64",
@@ -87,7 +86,7 @@ func GetRsyslogFiles(rsyslogConfig []byte, useExpectedContent bool) []extensions
 	return []extensionsv1alpha1.File{
 		{
 			Path:        "/var/lib/rsyslog-relp-configurator/rsyslog.d/60-audit.conf",
-			Permissions: ptr.To(uint32(0744)),
+			Permissions: new(uint32(0744)),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
 					Encoding: "b64",
@@ -97,7 +96,7 @@ func GetRsyslogFiles(rsyslogConfig []byte, useExpectedContent bool) []extensions
 		},
 		{
 			Path:        "/var/lib/rsyslog-relp-configurator/configure-rsyslog.sh",
-			Permissions: ptr.To(uint32(0744)),
+			Permissions: new(uint32(0744)),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
 					Encoding: "b64",
@@ -107,7 +106,7 @@ func GetRsyslogFiles(rsyslogConfig []byte, useExpectedContent bool) []extensions
 		},
 		{
 			Path:        "/var/lib/rsyslog-relp-configurator/process-rsyslog-pstats.sh",
-			Permissions: ptr.To(uint32(0744)),
+			Permissions: new(uint32(0744)),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
 					Encoding: "b64",
@@ -117,7 +116,7 @@ func GetRsyslogFiles(rsyslogConfig []byte, useExpectedContent bool) []extensions
 		},
 		{
 			Path:        "/etc/systemd/system/rsyslog.service.d/10-shoot-rsyslog-relp-memory-limits.conf",
-			Permissions: ptr.To(uint32(0644)),
+			Permissions: new(uint32(0644)),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
 					Data: GetBasedOnCondition(useExpectedContent, `[Service]
@@ -136,7 +135,7 @@ func GetRsyslogTLSFiles(useExpectedContent bool) []extensionsv1alpha1.File {
 	return []extensionsv1alpha1.File{
 		{
 			Path:        "/var/lib/rsyslog-relp-configurator/tls/ca.crt",
-			Permissions: ptr.To(uint32(0600)),
+			Permissions: new(uint32(0600)),
 			Content: extensionsv1alpha1.FileContent{
 				SecretRef: &extensionsv1alpha1.FileContentSecretRef{
 					Name:    GetBasedOnCondition(useExpectedContent, "ref-rsyslog-tls", "ref-rsyslog-tls-old"),
@@ -146,7 +145,7 @@ func GetRsyslogTLSFiles(useExpectedContent bool) []extensionsv1alpha1.File {
 		},
 		{
 			Path:        "/var/lib/rsyslog-relp-configurator/tls/tls.crt",
-			Permissions: ptr.To(uint32(0600)),
+			Permissions: new(uint32(0600)),
 			Content: extensionsv1alpha1.FileContent{
 				SecretRef: &extensionsv1alpha1.FileContentSecretRef{
 					Name:    GetBasedOnCondition(useExpectedContent, "ref-rsyslog-tls", "ref-rsyslog-tls-old"),
@@ -156,7 +155,7 @@ func GetRsyslogTLSFiles(useExpectedContent bool) []extensionsv1alpha1.File {
 		},
 		{
 			Path:        "/var/lib/rsyslog-relp-configurator/tls/tls.key",
-			Permissions: ptr.To(uint32(0600)),
+			Permissions: new(uint32(0600)),
 			Content: extensionsv1alpha1.FileContent{
 				SecretRef: &extensionsv1alpha1.FileContentSecretRef{
 					Name:    GetBasedOnCondition(useExpectedContent, "ref-rsyslog-tls", "ref-rsyslog-tls-old"),
@@ -171,9 +170,9 @@ func GetRsyslogTLSFiles(useExpectedContent bool) []extensionsv1alpha1.File {
 func GetRsyslogConfiguratorUnit(useExpectedContent bool) extensionsv1alpha1.Unit {
 	return extensionsv1alpha1.Unit{
 		Name:    "rsyslog-configurator.service",
-		Command: ptr.To(extensionsv1alpha1.CommandStart),
-		Enable:  ptr.To(true),
-		Content: ptr.To(GetBasedOnCondition(useExpectedContent, `[Unit]
+		Command: new(extensionsv1alpha1.CommandStart),
+		Enable:  new(true),
+		Content: new(GetBasedOnCondition(useExpectedContent, `[Unit]
 Description=rsyslog configurator daemon
 Documentation=https://github.com/gardener/gardener-extension-shoot-rsyslog-relp
 [Service]

--- a/test/common/configuration.go
+++ b/test/common/configuration.go
@@ -13,7 +13,6 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
 
 	rsyslogv1alpha1 "github.com/gardener/gardener-extension-shoot-rsyslog-relp/pkg/apis/rsyslog/v1alpha1"
 )
@@ -30,7 +29,7 @@ func AddOrUpdateRsyslogRelpExtension(shoot *gardencorev1beta1.Shoot, opts ...fun
 		LoggingRules: []rsyslogv1alpha1.LoggingRule{
 			{
 				ProgramNames: []string{"test-program"},
-				Severity:     ptr.To(1),
+				Severity:     new(1),
 			},
 		},
 	}

--- a/test/e2e/create_enable_disable_delete.go
+++ b/test/e2e/create_enable_disable_delete.go
@@ -15,7 +15,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener-extension-shoot-rsyslog-relp/pkg/apis/rsyslog/v1alpha1"
@@ -145,10 +144,10 @@ var _ = Describe("Shoot Rsyslog Relp Extension Tests", func() {
 		enableExtensionFunc := func(shoot *gardencorev1beta1.Shoot) error {
 			loggingRule := v1alpha1.LoggingRule{
 				ProgramNames: []string{"filter-program"},
-				Severity:     ptr.To(3),
+				Severity:     new(3),
 				MessageContent: &v1alpha1.MessageContent{
-					Regex:   ptr.To("included"),
-					Exclude: ptr.To("excluded"),
+					Regex:   new("included"),
+					Exclude: new("excluded"),
 				},
 			}
 

--- a/test/e2e/test_common.go
+++ b/test/e2e/test_common.go
@@ -15,7 +15,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener-extension-shoot-rsyslog-relp/imagevector"
@@ -83,7 +82,7 @@ func deployRsyslogRelpInstaller(ctx context.Context, c kubernetes.Interface) err
 						Command: []string{"/bin/sh", "-c"},
 						Args:    []string{"chroot /hostroot apt-get update && chroot /hostroot apt-get install -y rsyslog-relp"},
 						SecurityContext: &corev1.SecurityContext{
-							Privileged: ptr.To(true),
+							Privileged: new(true),
 						},
 						VolumeMounts: []corev1.VolumeMount{{
 							Name:      "root-volume",

--- a/test/integration/controller/lifecycle/lifecycle_test.go
+++ b/test/integration/controller/lifecycle/lifecycle_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener-extension-shoot-rsyslog-relp/pkg/apis/rsyslog"
@@ -44,7 +43,7 @@ var _ = Describe("Lifecycle controller tests", func() {
 				Namespace: "kube-system",
 			},
 			Spec: appsv1.DaemonSetSpec{
-				RevisionHistoryLimit: ptr.To(int32(2)),
+				RevisionHistoryLimit: new(int32(2)),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"app.kubernetes.io/instance": "rsyslog-relp-configuration-cleaner",
@@ -59,14 +58,14 @@ var _ = Describe("Lifecycle controller tests", func() {
 						},
 					},
 					Spec: corev1.PodSpec{
-						AutomountServiceAccountToken: ptr.To(false),
+						AutomountServiceAccountToken: new(false),
 						Containers: []corev1.Container{
 							{
 								Image:           "registry.k8s.io/pause:3.10",
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Name:            "pause-container",
 								SecurityContext: &corev1.SecurityContext{
-									AllowPrivilegeEscalation: ptr.To(false),
+									AllowPrivilegeEscalation: new(false),
 								},
 							},
 						},
@@ -121,7 +120,7 @@ fi`,
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Name:            "rsyslog-relp-configuration-cleaner",
 								SecurityContext: &corev1.SecurityContext{
-									AllowPrivilegeEscalation: ptr.To(false),
+									AllowPrivilegeEscalation: new(false),
 								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
@@ -136,7 +135,7 @@ fi`,
 									{
 										Name:             "host-root-volume",
 										MountPath:        "/host",
-										MountPropagation: ptr.To(corev1.MountPropagationHostToContainer),
+										MountPropagation: new(corev1.MountPropagationHostToContainer),
 									},
 								},
 							},
@@ -224,16 +223,16 @@ fi`,
 			Port:   10250,
 			LoggingRules: []rsyslog.LoggingRule{
 				{
-					Severity:       ptr.To(5),
+					Severity:       new(5),
 					ProgramNames:   []string{"systemd", "audisp-syslog"},
-					MessageContent: &rsyslog.MessageContent{Regex: ptr.To("testing"), Exclude: ptr.To("not")},
+					MessageContent: &rsyslog.MessageContent{Regex: new("testing"), Exclude: new("not")},
 				},
 				{
-					Severity:     ptr.To(7),
+					Severity:     new(7),
 					ProgramNames: []string{"kubelet"},
 				},
 				{
-					Severity: ptr.To(2),
+					Severity: new(2),
 				},
 			},
 		}

--- a/test/integration/webhook/operatingsystemconfig/operatingsystemconfig_suite_test.go
+++ b/test/integration/webhook/operatingsystemconfig/operatingsystemconfig_suite_test.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	controllerconfig "sigs.k8s.io/controller-runtime/pkg/config"
@@ -126,7 +125,7 @@ var _ = BeforeSuite(func() {
 			DefaultNamespaces: map[string]cache.Config{testNamespace.Name: {}},
 		},
 		Controller: controllerconfig.Controller{
-			SkipNameValidation: ptr.To(true),
+			SkipNameValidation: new(true),
 		},
 	})
 	Expect(err).NotTo(HaveOccurred())

--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -14,7 +14,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	rsyslogv1alpha1 "github.com/gardener/gardener-extension-shoot-rsyslog-relp/pkg/apis/rsyslog/v1alpha1"
@@ -123,7 +122,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 				common.AddOrUpdateRsyslogRelpExtension(
 					shoot,
 					common.WithTarget(echoServerIP),
-					common.AppendLoggingRule(rsyslogv1alpha1.LoggingRule{ProgramNames: []string{"audisp-syslog", "audispd"}, Severity: ptr.To(7)}),
+					common.AppendLoggingRule(rsyslogv1alpha1.LoggingRule{ProgramNames: []string{"audisp-syslog", "audispd"}, Severity: new(7)}),
 				)
 				return nil
 			})
@@ -159,7 +158,7 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 					common.WithPort(443),
 					common.WithTLSWithSecretRefNameAndTLSLib(secretReferenceName, "openssl"),
 					common.WithTarget(echoServerIP),
-					common.AppendLoggingRule(rsyslogv1alpha1.LoggingRule{ProgramNames: []string{"audisp-syslog", "audispd"}, Severity: ptr.To(7)}),
+					common.AppendLoggingRule(rsyslogv1alpha1.LoggingRule{ProgramNames: []string{"audisp-syslog", "audispd"}, Severity: new(7)}),
 				)
 				common.AddOrUpdateResourceReference(shoot, secretReferenceName, "Secret", createdResources[0].GetName())
 				return nil
@@ -204,8 +203,8 @@ var _ = Describe("Shoot rsyslog-relp testing", func() {
 				common.AddOrUpdateRsyslogRelpExtension(
 					shoot,
 					common.WithTarget(echoServerIP),
-					common.AppendLoggingRule(rsyslogv1alpha1.LoggingRule{ProgramNames: []string{"audisp-syslog", "audispd"}, Severity: ptr.To(7)}),
-					common.WithAuditConfig(&rsyslogv1alpha1.AuditConfig{Enabled: true, ConfigMapReferenceName: ptr.To(configMapRefName)}),
+					common.AppendLoggingRule(rsyslogv1alpha1.LoggingRule{ProgramNames: []string{"audisp-syslog", "audispd"}, Severity: new(7)}),
+					common.WithAuditConfig(&rsyslogv1alpha1.AuditConfig{Enabled: true, ConfigMapReferenceName: new(configMapRefName)}),
 				)
 				common.AddOrUpdateResourceReference(shoot, configMapRefName, "ConfigMap", createdResources[0].GetName())
 				return nil


### PR DESCRIPTION
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:

Uses Go's `new` built-in instead of `ptr.To` for pointer literals now that the repository targets Go 1.26. This removes 109 helper calls and the imports that became unused.

**Which issue(s) this PR fixes**:
Fixes #419

**Special notes for your reviewer**:

`go test ./cmd/... ./pkg/...` passes.

**Release note**:
```other developer
NONE
```
